### PR TITLE
MotionMark: improve drag and drop feedback on developer page

### DIFF
--- a/MotionMark/resources/debug-runner/motionmark.css
+++ b/MotionMark/resources/debug-runner/motionmark.css
@@ -287,9 +287,8 @@ label.tree-label {
     color: rgb(235, 235, 235);
 }
 
-#drop-target:hover {
+#drop-target.drag-over {
     background-color: rgba(255, 255, 255, .1);
-    cursor: pointer;
 }
 
 #options ul {

--- a/MotionMark/resources/debug-runner/motionmark.js
+++ b/MotionMark/resources/debug-runner/motionmark.js
@@ -560,15 +560,27 @@ Utilities.extendObject(window.benchmarkController, {
             e.stopPropagation();
             e.preventDefault();
         }
-        dropTarget.addEventListener("dragenter", stopEvent, false);
-        dropTarget.addEventListener("dragover", stopEvent, false);
-        dropTarget.addEventListener("dragleave", stopEvent, false);
-        dropTarget.addEventListener("drop", function (e) {
-            e.stopPropagation();
-            e.preventDefault();
+        dropTarget.addEventListener("dragenter", (e) => {
+            dropTarget.classList.add("drag-over");
+            stopEvent(e);
+        }, false);
 
-            if (!e.dataTransfer.files.length)
+        dropTarget.addEventListener("dragover", stopEvent, false);
+
+        dropTarget.addEventListener("dragleave", (e) => {
+            dropTarget.classList.remove("drag-over");
+            stopEvent(e);
+        }, false);
+
+        dropTarget.addEventListener("drop", function (e) {
+            stopEvent(e);
+
+            if (!e.dataTransfer.files.length) {
+                dropTarget.classList.remove("drag-over");
                 return;
+            }
+
+            dropTarget.textContent = 'Processing…';
 
             var file = e.dataTransfer.files[0];
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=260099
rdar://113772977

Reviewed by Tim Nguyen.

The MotionMark developer.html page allows you to drag and drop a JSON file, but the drop target didn't highlight on drag-over, and there was no feedback after dropping, even though things can be processing for a few seconds. So fix both issues.

* PerformanceTests/MotionMark/resources/debug-runner/motionmark.css: (#drop-target.drag-over):
(#drop-target:hover): Deleted.
* PerformanceTests/MotionMark/resources/debug-runner/motionmark.js: