### PR TITLE
Fix the graph display

### DIFF
--- a/MotionMark/developer.html
+++ b/MotionMark/developer.html
@@ -167,8 +167,8 @@
                 <header>
                     <button onclick="benchmarkController.showResults()">&lt; Results</button>
                     <h1>Graph:</h1>
-                    <p class="score"></p>
-                    <p class="confidence"></p>
+                    <p class="score">&nbsp;</p>
+                    <p class="confidence">&nbsp;</p>
                 </header>
                 <nav>
                     <form name="graph-type">

--- a/MotionMark/resources/debug-runner/motionmark.css
+++ b/MotionMark/resources/debug-runner/motionmark.css
@@ -570,10 +570,6 @@ body.showing-test-container.tiles-classic {
     flex-direction: row;
 }
 
-#test-graph {
-    flex: 1 0 calc(100% - 40px);
-}
-
 #test-graph h1 {
     margin-bottom: 0;
 }
@@ -626,7 +622,29 @@ body.showing-test-container.tiles-classic {
 /*                           Graph Section                                    */
 /* -------------------------------------------------------------------------- */
 
+body.showing-test-graph {
+	height: 100vh;
+}
+
+body.showing-test-graph main, #test-graph {
+	height: 100%;
+}
+
+body.showing-test-graph header, body.showing-test-graph nav {
+	flex-basis: auto;
+}
+
+#test-graph .body {
+	display: flex;
+	flex-direction: column;
+	margin-trim: block-start;
+	margin: 1em;
+	height: calc(100% - 2em);
+}
+
 #test-graph-data {
+	flex-grow: 1;
+	min-height: 0;
     z-index: 1;
     font: 10px sans-serif;
     color: rgb(235, 235, 235);
@@ -634,7 +652,7 @@ body.showing-test-container.tiles-classic {
 
 #test-graph-data > svg {
     fill: none;
-    overflow: visible;
+/*    overflow: hidden;*/
 }
 
 .axis path,


### PR DESCRIPTION
This change fixes various issues in the graph display.

First, the graphs overflowed the page and triggered scrolling. Fix by using flex layout for `#test-graph .body`, with a fixed-height header, and a flexible `#test-graph-data` element. Graph layout uses getBoundingClientRect() on that lower box, using the result to size the SVG. To make this work, the header has to have the final height, so pre-fill header fields with a non-breaking space so they have height before they get the actual values (which happens after graph building).

Second, the graphs were hardcoded for 60fps. Make them scale for other frame rates, supplying some reasonable set of axis labels for common frame rates, and computing a set otherwise.