### PR TITLE
Use JS class syntax in harness code

### DIFF
--- a/MotionMark/resources/debug-runner/debug-runner.js
+++ b/MotionMark/resources/debug-runner/debug-runner.js
@@ -22,34 +22,35 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-ProgressBar = Utilities.createClass(
-    function(element, ranges)
+
+class ProgressBar {
+    constructor(element, ranges)
     {
         this._element = element;
         this._ranges = ranges;
         this._currentRange = 0;
         this._updateElement();
-    }, {
+    }
 
-    _updateElement: function()
+    _updateElement()
     {
         this._element.style.width = (this._currentRange * (100 / this._ranges)) + "%";
-    },
+    }
 
-    incrementRange: function()
+    incrementRange()
     {
         ++this._currentRange;
         this._updateElement();
     }
-});
+}
 
-DeveloperResultsTable = Utilities.createSubclass(ResultsTable,
-    function(element, headers)
+class DeveloperResultsTable extends ResultsTable {
+    constructor(element, headers)
     {
-        ResultsTable.call(this, element, headers);
-    }, {
+        super(element, headers);
+    }
 
-    _addGraphButton: function(td, testName, testResult, testData)
+    _addGraphButton(td, testName, testResult, testData)
     {
         var button = Utilities.createElement("button", { class: "small-button" }, td);
         button.textContent = Strings.text.graph + "…";
@@ -60,9 +61,9 @@ DeveloperResultsTable = Utilities.createSubclass(ResultsTable,
         button.addEventListener("click", function(e) {
             benchmarkController.showTestGraph(e.target.testName, e.target.testResult, e.target.testData);
         });
-    },
+    }
 
-    _isNoisyMeasurement: function(jsonExperiment, data, measurement, options)
+    _isNoisyMeasurement(jsonExperiment, data, measurement, options)
     {
         const percentThreshold = 10;
         const averageThreshold = 2;
@@ -74,9 +75,9 @@ DeveloperResultsTable = Utilities.createSubclass(ResultsTable,
             return Math.abs(data[Strings.json.measurements.average] - options["frame-rate"]) >= averageThreshold;
 
         return false;
-    },
+    }
 
-    _addTest: function(testName, testResult, options, testData)
+    _addTest(testName, testResult, options, testData)
     {
         var row = Utilities.createElement("tr", {}, this.element);
 
@@ -120,7 +121,7 @@ DeveloperResultsTable = Utilities.createSubclass(ResultsTable,
                 td.textContent = header.text(testResult);
         }, this);
     }
-});
+}
 
 Utilities.extendObject(window.benchmarkRunnerClient, {
     testsCount: null,

--- a/MotionMark/resources/extensions.js
+++ b/MotionMark/resources/extensions.js
@@ -22,8 +22,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-Utilities = {
-    _parse: function(str, sep)
+
+class Utilities {
+    static _parse(str, sep)
     {
         var output = {};
         str.split(sep).forEach(function(part) {
@@ -35,51 +36,52 @@ Utilities = {
                 output[item[0]] = value;
           });
         return output;
-    },
+    }
 
-    parseParameters: function()
+    static parseParameters(windowLocation)
     {
-        return this._parse(window.location.search.substr(1), "&");
-    },
+        return this._parse(windowLocation.search.substr(1), "&");
+    }
 
-    parseArguments: function(str)
+    static parseArguments(str)
     {
         return this._parse(str, " ");
-    },
+    }
 
-    extendObject: function(obj1, obj2)
+    static extendObject(obj1, obj2)
     {
         for (var attrname in obj2)
             obj1[attrname] = obj2[attrname];
         return obj1;
-    },
+    }
 
-    copyObject: function(obj)
+    static copyObject(obj)
     {
         return this.extendObject({}, obj);
-    },
+    }
 
-    mergeObjects: function(obj1, obj2)
+    static mergeObjects(obj1, obj2)
     {
         return this.extendObject(this.copyObject(obj1), obj2);
-    },
+    }
 
-    createClass: function(classConstructor, classMethods)
+    // FIXME: This should go away once the benchmark is fully converted to JS class syntax.
+    static createClass(classConstructor, classMethods)
     {
         classConstructor.prototype = classMethods;
         return classConstructor;
-    },
+    }
 
-    createSubclass: function(superclass, classConstructor, classMethods)
+    static createSubclass(superclass, classConstructor, classMethods)
     {
         classConstructor.prototype = Object.create(superclass.prototype);
         classConstructor.prototype.constructor = classConstructor;
         if (classMethods)
             Utilities.extendObject(classConstructor.prototype, classMethods);
         return classConstructor;
-    },
+    }
 
-    createElement: function(name, attrs, parentElement)
+    static createElement(name, attrs, parentElement)
     {
         var element = document.createElement(name);
 
@@ -88,9 +90,9 @@ Utilities = {
 
         parentElement.appendChild(element);
         return element;
-    },
+    }
 
-    createSVGElement: function(name, attrs, xlinkAttrs, parentElement)
+    static createSVGElement(name, attrs, xlinkAttrs, parentElement)
     {
         const svgNamespace = "http://www.w3.org/2000/svg";
         const xlinkNamespace = "http://www.w3.org/1999/xlink";
@@ -105,9 +107,9 @@ Utilities = {
 
         parentElement.appendChild(element);
         return element;
-    },
+    }
 
-    browserPrefix: function()
+    static browserPrefix()
     {
         if (this._browserPrefix !== undefined)
             return this._browserPrefix;
@@ -139,19 +141,19 @@ Utilities = {
         };
 
         return this._browserPrefix;
-    },
+    }
 
-    setElementPrefixedProperty: function(element, property, value)
+    static setElementPrefixedProperty(element, property, value)
     {
         element.style[property] = element.style[this.browserPrefix().js + property[0].toUpperCase() + property.substr(1)] = value;
-    },
+    }
 
-    stripUnwantedCharactersForURL: function(inputString)
+    static stripUnwantedCharactersForURL(inputString)
     {
         return inputString.replace(/\W/g, '');
-    },
+    }
 
-    convertObjectToQueryString: function(object)
+    static convertObjectToQueryString(object)
     {
         var queryString = [];
         for (var property in object) {
@@ -159,9 +161,9 @@ Utilities = {
                 queryString.push(encodeURIComponent(property) + "=" + encodeURIComponent(object[property]));
         }
         return "?" + queryString.join("&");
-    },
+    }
 
-    convertQueryStringToObject: function(queryString)
+    static convertQueryStringToObject(queryString)
     {
         queryString = queryString.substring(1);
         if (!queryString)
@@ -173,25 +175,25 @@ Utilities = {
             object[components[0]] = components[1];
         });
         return object;
-    },
+    }
 
-    progressValue: function(value, min, max)
+    static progressValue(value, min, max)
     {
         return (value - min) / (max - min);
-    },
+    }
 
-    lerp: function(value, min, max)
+    static lerp(value, min, max)
     {
         return min + (max - min) * value;
-    },
+    }
 
-    toFixedNumber: function(number, precision)
+    static toFixedNumber(number, precision)
     {
         if (number.toFixed)
             return Number(number.toFixed(precision));
         return number;
     }
-};
+}
 
 Array.prototype.swap = function(i, j)
 {
@@ -252,171 +254,173 @@ Array.prototype.shuffle = function()
     return this;
 }
 
-Point = Utilities.createClass(
-    function(x, y)
+class Point {
+
+    static zero = new Point(0, 0);
+    
+    constructor(x, y)
     {
         this.x = x;
         this.y = y;
-    }, {
+    }
 
     // Used when the point object is used as a size object.
     get width()
     {
         return this.x;
-    },
+    }
 
     // Used when the point object is used as a size object.
     get height()
     {
         return this.y;
-    },
+    }
 
     // Used when the point object is used as a size object.
     get center()
     {
         return new Point(this.x / 2, this.y / 2);
-    },
+    }
 
-    str: function()
+    str()
     {
         return "x = " + this.x + ", y = " + this.y;
-    },
+    }
 
-    add: function(other)
+    add(other)
     {
         if(isNaN(other.x))
             return new Point(this.x + other, this.y + other);
         return new Point(this.x + other.x, this.y + other.y);
-    },
+    }
 
-    subtract: function(other)
+    subtract(other)
     {
         if(isNaN(other.x))
             return new Point(this.x - other, this.y - other);
         return new Point(this.x - other.x, this.y - other.y);
-    },
+    }
 
-    multiply: function(other)
+    multiply(other)
     {
         if(isNaN(other.x))
             return new Point(this.x * other, this.y * other);
         return new Point(this.x * other.x, this.y * other.y);
-    },
+    }
 
-    move: function(angle, velocity, timeDelta)
+    move(angle, velocity, timeDelta)
     {
         return this.add(Point.pointOnCircle(angle, velocity * (timeDelta / 1000)));
-    },
+    }
 
-    length: function() {
+    length()
+    {
         return Math.sqrt( this.x * this.x + this.y * this.y );
-    },
+    }
 
-    normalize: function() {
+    normalize()
+    {
         var l = Math.sqrt( this.x * this.x + this.y * this.y );
         this.x /= l;
         this.y /= l;
         return this;
     }
-});
 
-Utilities.extendObject(Point, {
-    zero: new Point(0, 0),
-
-    pointOnCircle: function(angle, radius)
+    static pointOnCircle(angle, radius)
     {
         return new Point(radius * Math.cos(angle), radius * Math.sin(angle));
-    },
+    }
 
-    pointOnEllipse: function(angle, radiuses)
+    static pointOnEllipse(angle, radiuses)
     {
         return new Point(radiuses.x * Math.cos(angle), radiuses.y * Math.sin(angle));
-    },
+    }
 
-    elementClientSize: function(element)
+    static elementClientSize(element)
     {
         var rect = element.getBoundingClientRect();
         return new Point(rect.width, rect.height);
     }
-});
+}
 
-Insets = Utilities.createClass(
-    function(top, right, bottom, left)
+class Insets {
+    constructor (top, right, bottom, left)
     {
         this.top = top;
         this.right = right;
         this.bottom = bottom;
         this.left = left;
-    }, {
+    }
 
     get width()
     {
         return this.left + this.right;
-    },
+    }
 
     get height()
     {
         return this.top + this.bottom;
-    },
+    }
 
     get size()
     {
         return new Point(this.width, this.height);
     }
-});
 
-Insets.elementPadding = function(element)
-{
-    var styles = window.getComputedStyle(element);
-    return new Insets(
-        parseFloat(styles.paddingTop),
-        parseFloat(styles.paddingRight),
-        parseFloat(styles.paddingBottom),
-        parseFloat(styles.paddingTop));
+    static elementPadding(element)
+    {
+        const styles = window.getComputedStyle(element);
+        return new Insets(
+            parseFloat(styles.paddingTop),
+            parseFloat(styles.paddingRight),
+            parseFloat(styles.paddingBottom),
+            parseFloat(styles.paddingTop));
+    }
 }
 
-UnitBezier = Utilities.createClass(
-    function(point1, point2)
+class UnitBezier {
+    static epsilon = 1e-5;
+    static derivativeEpsilon = 1e-6;
+
+    constructor(point1, point2)
     {
-        // First and last points in the Bézier curve are assumed to be (0,0) and (!,1)
+        // First and last points in the Bézier curve are assumed to be (0,0) and (1,1)
         this._c = point1.multiply(3);
         this._b = point2.subtract(point1).multiply(3).subtract(this._c);
         this._a = new Point(1, 1).subtract(this._c).subtract(this._b);
-    }, {
+    }
 
-    epsilon: 1e-5,
-    derivativeEpsilon: 1e-6,
 
-    solve: function(x)
+    solve(x)
     {
         return this.sampleY(this.solveForT(x));
-    },
+    }
 
-    sampleX: function(t)
+    sampleX(t)
     {
         return ((this._a.x * t + this._b.x) * t + this._c.x) * t;
-    },
+    }
 
-    sampleY: function(t)
+    sampleY(t)
     {
         return ((this._a.y * t + this._b.y) * t + this._c.y) * t;
-    },
+    }
 
-    sampleDerivativeX: function(t)
+    sampleDerivativeX(t)
     {
         return(3 * this._a.x * t + 2 * this._b.x) * t + this._c.x;
-    },
+    }
 
-    solveForT: function(x)
+    solveForT(x)
     {
-        var t0, t1, t2, x2, d2, i;
+        let t0, t1, t2, x2, d2, i;
 
         for (t2 = x, i = 0; i < 8; ++i) {
             x2 = this.sampleX(t2) - x;
-            if (Math.abs(x2) < this.epsilon)
+            if (Math.abs(x2) < UnitBezier.epsilon)
                 return t2;
             d2 = this.sampleDerivativeX(t2);
-            if (Math.abs(d2) < this.derivativeEpsilon)
+            if (Math.abs(d2) < UnitBezier.derivativeEpsilon)
                 break;
             t2 = t2 - x2 / d2;
         }
@@ -432,7 +436,7 @@ UnitBezier = Utilities.createClass(
 
         while (t0 < t1) {
             x2 = this.sampleX(t2);
-            if (Math.abs(x2 - x) < this.epsilon)
+            if (Math.abs(x2 - x) < UnitBezier.epsilon)
                 return t2;
             if (x > x2)
                 t0 = t2;
@@ -443,7 +447,7 @@ UnitBezier = Utilities.createClass(
 
         return t2;
     }
-});
+}
 
 SimplePromise = Utilities.createClass(
     function()
@@ -483,14 +487,14 @@ SimplePromise = Utilities.createClass(
     }
 });
 
-var Heap = Utilities.createClass(
-    function(maxSize, compare)
+class Heap {
+    constructor(maxSize, compare)
     {
         this._maxSize = maxSize;
         this._compare = compare;
         this._size = 0;
         this._values = new Array(this._maxSize);
-    }, {
+    }
 
     // This is a binary heap represented in an array. The root element is stored
     // in the first element in the array. The root is followed by its two children.
@@ -503,25 +507,25 @@ var Heap = Utilities.createClass(
     // LEFT         1       3       5       7       9       11      13
     // RIGHT        2       4       6       8       10      12      14
     // ===========================================================================
-    _parentIndex: function(i)
+    _parentIndex(i)
     {
         return i > 0 ? Math.floor((i - 1) / 2) : -1;
-    },
+    }
 
-    _leftIndex: function(i)
+    _leftIndex(i)
     {
         var leftIndex = i * 2 + 1;
         return leftIndex < this._size ? leftIndex : -1;
-    },
+    }
 
-    _rightIndex: function(i)
+    _rightIndex(i)
     {
         var rightIndex = i * 2 + 2;
         return rightIndex < this._size ? rightIndex : -1;
-    },
+    }
 
     // Return the child index that may violate the heap property at index i.
-    _childIndex: function(i)
+    _childIndex(i)
     {
         var left = this._leftIndex(i);
         var right = this._rightIndex(i);
@@ -530,19 +534,19 @@ var Heap = Utilities.createClass(
             return this._compare(this._values[left], this._values[right]) > 0 ? left : right;
 
         return left != -1 ? left : right;
-    },
+    }
 
-    init: function()
+    init()
     {
         this._size = 0;
-    },
+    }
 
-    top: function()
+    top()
     {
         return this._size ? this._values[0] : NaN;
-    },
+    }
 
-    push: function(value)
+    push(value)
     {
         if (this._size == this._maxSize) {
             // If size is bounded and the new value can be a parent of the top()
@@ -553,18 +557,18 @@ var Heap = Utilities.createClass(
         }
         this._values[this._size++] = value;
         this._bubble(this._size - 1);
-    },
+    }
 
-    pop: function()
+    pop()
     {
         if (!this._size)
             return NaN;
 
         this._values[0] = this._values[--this._size];
         this._sink(0);
-    },
+    }
 
-    _bubble: function(i)
+    _bubble(i)
     {
         // Fix the heap property at index i given that parent is the only node that
         // may violate the heap property.
@@ -574,9 +578,9 @@ var Heap = Utilities.createClass(
 
             this._values.swap(pi, i);
         }
-    },
+    }
 
-    _sink: function(i)
+    _sink(i)
     {
         // Fix the heap property at index i given that each of the left and the right
         // sub-trees satisfies the heap property.
@@ -586,9 +590,9 @@ var Heap = Utilities.createClass(
 
             this._values.swap(ci, i);
         }
-    },
+    }
 
-    str: function()
+    str()
     {
         var out = "Heap[" + this._size + "] = [";
         for (var i = 0; i < this._size; ++i) {
@@ -597,97 +601,97 @@ var Heap = Utilities.createClass(
                 out += ", ";
         }
         return out + "]";
-    },
+    }
 
-    values: function(size) {
+    values(size)
+    {
         // Return the last "size" heap elements values.
         var values = this._values.slice(0, this._size);
         return values.sort(this._compare).slice(0, Math.min(size, this._size));
     }
-});
 
-Utilities.extendObject(Heap, {
-    createMinHeap: function(maxSize)
+    static createMinHeap(maxSize)
     {
         return new Heap(maxSize, function(a, b) { return b - a; });
-    },
+    }
 
-    createMaxHeap: function(maxSize) {
+    static createMaxHeap(maxSize)
+    {
         return new Heap(maxSize, function(a, b) { return a - b; });
     }
-});
+}
 
-var SampleData = Utilities.createClass(
-    function(fieldMap, data)
+class SampleData {
+    constructor(fieldMap, data)
     {
         this.fieldMap = fieldMap || {};
         this.data = data || [];
-    }, {
+    }
 
     get length()
     {
         return this.data.length;
-    },
+    }
 
-    addField: function(name, index)
+    addField(name, index)
     {
         this.fieldMap[name] = index;
-    },
+    }
 
-    push: function(datum)
+    push(datum)
     {
         this.data.push(datum);
-    },
+    }
 
-    sort: function(sortFunction)
+    sort(sortFunction)
     {
         this.data.sort(sortFunction);
-    },
+    }
 
-    slice: function(begin, end)
+    slice(begin, end)
     {
         return new SampleData(this.fieldMap, this.data.slice(begin, end));
-    },
+    }
 
-    forEach: function(iterationFunction)
+    forEach(iterationFunction)
     {
         this.data.forEach(iterationFunction);
-    },
+    }
 
-    createDatum: function()
+    createDatum()
     {
         return [];
-    },
+    }
 
-    getFieldInDatum: function(datum, fieldName)
+    getFieldInDatum(datum, fieldName)
     {
         if (typeof datum === 'number')
             datum = this.data[datum];
         return datum[this.fieldMap[fieldName]];
-    },
+    }
 
-    setFieldInDatum: function(datum, fieldName, value)
+    setFieldInDatum(datum, fieldName, value)
     {
         if (typeof datum === 'number')
             datum = this.data[datum];
         return datum[this.fieldMap[fieldName]] = value;
-    },
+    }
 
-    at: function(index)
+    at(index)
     {
         return this.data[index];
-    },
+    }
 
-    toArray: function()
+    toArray()
     {
-        var array = [];
+        let array = [];
 
         this.data.forEach(function(datum) {
-            var newDatum = {};
+            let newDatum = {};
             array.push(newDatum);
 
-            for (var fieldName in this.fieldMap) {
-                var value = this.getFieldInDatum(datum, fieldName);
+            for (let fieldName in this.fieldMap) {
+                let value = this.getFieldInDatum(datum, fieldName);
                 if (value !== null && value !== undefined)
                     newDatum[fieldName] = value;
             }
@@ -695,4 +699,4 @@ var SampleData = Utilities.createClass(
 
         return array;
     }
-});
+}

--- a/MotionMark/resources/runner/benchmark-runner.js
+++ b/MotionMark/resources/runner/benchmark-runner.js
@@ -1,29 +1,29 @@
-BenchmarkRunnerState = Utilities.createClass(
-    function(suites)
+class BenchmarkRunnerState {
+    constructor(suites)
     {
         this._suites = suites;
         this._suiteIndex = -1;
         this._testIndex = 0;
         this.next();
-    }, {
+    }
 
-    currentSuite: function()
+    currentSuite()
     {
         return this._suites[this._suiteIndex];
-    },
+    }
 
-    currentTest: function()
+    currentTest()
     {
         var suite = this.currentSuite();
         return suite ? suite.tests[this._testIndex] : null;
-    },
+    }
 
-    isFirstTest: function()
+    isFirstTest()
     {
         return !this._testIndex;
-    },
+    }
 
-    next: function()
+    next()
     {
         this._testIndex++;
 
@@ -35,9 +35,9 @@ BenchmarkRunnerState = Utilities.createClass(
         do {
             this._suiteIndex++;
         } while (this._suiteIndex < this._suites.length && this._suites[this._suiteIndex].disabled);
-    },
+    }
 
-    prepareCurrentTest: function(runner, frame)
+    prepareCurrentTest(runner, frame)
     {
         var test = this.currentTest();
         var promise = new SimplePromise;
@@ -49,17 +49,17 @@ BenchmarkRunnerState = Utilities.createClass(
         frame.src = "tests/" + test.url;
         return promise;
     }
-});
+}
 
-BenchmarkRunner = Utilities.createClass(
-    function(suites, frameContainer, client)
+class BenchmarkRunner {
+    constructor(suites, frameContainer, client)
     {
         this._suites = suites;
         this._client = client;
         this._frameContainer = frameContainer;
-    }, {
+    }
 
-    _appendFrame: function()
+    _appendFrame()
     {
         var frame = document.createElement("iframe");
         frame.setAttribute("scrolling", "no");
@@ -67,17 +67,17 @@ BenchmarkRunner = Utilities.createClass(
         this._frameContainer.insertBefore(frame, this._frameContainer.firstChild);
         this._frame = frame;
         return frame;
-    },
+    }
 
-    _removeFrame: function()
+    _removeFrame()
     {
         if (this._frame) {
             this._frame.parentNode.removeChild(this._frame);
             this._frame = null;
         }
-    },
+    }
 
-    _runBenchmarkAndRecordResults: function(state)
+    _runBenchmarkAndRecordResults(state)
     {
         var promise = new SimplePromise;
         var suite = state.currentSuite();
@@ -91,7 +91,7 @@ BenchmarkRunner = Utilities.createClass(
 
         var options = { complexity: test.complexity };
         Utilities.extendObject(options, this._client.options);
-        Utilities.extendObject(options, contentWindow.Utilities.parseParameters());
+        Utilities.extendObject(options, Utilities.parseParameters(contentWindow.location));
 
         var benchmark = new contentWindow.benchmarkClass(options);
         document.body.style.backgroundColor = benchmark.backgroundColor();
@@ -110,9 +110,9 @@ BenchmarkRunner = Utilities.createClass(
         });
 
         return promise;
-    },
+    }
 
-    step: function(state)
+    step(state)
     {
         if (!state) {
             state = new BenchmarkRunnerState(this._suites);
@@ -134,18 +134,18 @@ BenchmarkRunner = Utilities.createClass(
         return state.prepareCurrentTest(this, this._frame).then(function(prepareReturnValue) {
             return this._runBenchmarkAndRecordResults(state);
         }.bind(this));
-    },
+    }
 
-    runAllSteps: function(startingState)
+    runAllSteps(startingState)
     {
         var nextCallee = this.runAllSteps.bind(this);
         this.step(startingState).then(function(nextState) {
             if (nextState)
                 nextCallee(nextState);
         });
-    },
+    }
 
-    runMultipleIterations: function()
+    runMultipleIterations()
     {
         var self = this;
         var currentIteration = 0;
@@ -164,9 +164,9 @@ BenchmarkRunner = Utilities.createClass(
             this._client.willStartFirstIteration();
 
         this.runAllSteps();
-    },
+    }
 
-    _finalize: function()
+    _finalize()
     {
         this._removeFrame();
 
@@ -176,4 +176,4 @@ BenchmarkRunner = Utilities.createClass(
         if (this._runNextIteration)
             this._runNextIteration();
     }
-});
+}

--- a/MotionMark/resources/runner/motionmark.js
+++ b/MotionMark/resources/runner/motionmark.js
@@ -22,8 +22,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
- ResultsDashboard = Utilities.createClass(
-    function(version, options, testData)
+
+class ResultsDashboard {
+    constructor(version, options, testData)
     {
         this._iterationsSamplers = [];
         this._options = options;
@@ -35,14 +36,14 @@
             this._iterationsSamplers = testData;
             this._processData();
         }
-    }, {
+    }
 
-    push: function(suitesSamplers)
+    push(suitesSamplers)
     {
         this._iterationsSamplers.push(suitesSamplers);
-    },
+    }
 
-    _processData: function()
+    _processData()
     {
         this._results = {};
         this._results[Strings.json.results.iterations] = [];
@@ -89,13 +90,14 @@
         this._results[Strings.json.score] = Statistics.sampleMean(iterationsScores.length, iterationsScores.reduce(function(a, b) { return a + b; }));
         this._results[Strings.json.scoreLowerBound] = this._results[Strings.json.results.iterations][0][Strings.json.scoreLowerBound];
         this._results[Strings.json.scoreUpperBound] = this._results[Strings.json.results.iterations][0][Strings.json.scoreUpperBound];
-    },
+    }
 
-    calculateScore: function(data)
+    calculateScore(data)
     {
         var result = {};
         data[Strings.json.result] = result;
         var samples = data[Strings.json.samples];
+        const desiredFrameLength = 1000 / this._targetFrameRate;
 
         function findRegression(series, profile) {
             var minIndex = Math.round(.025 * series.length);
@@ -112,7 +114,7 @@
 
             var complexityIndex = series.fieldMap[Strings.json.complexity];
             var frameLengthIndex = series.fieldMap[Strings.json.frameLength];
-            var regressionOptions = { desiredFrameLength: 1000/this._targetFrameRate };
+            var regressionOptions = { desiredFrameLength: desiredFrameLength };
             if (profile)
                 regressionOptions.preferredProfile = profile;
             return {
@@ -237,12 +239,12 @@
             result[Strings.json.scoreLowerBound] = result[Strings.json.score] - averageFrameLength.standardDeviation();
             result[Strings.json.scoreUpperBound] = result[Strings.json.score] + averageFrameLength.standardDeviation();
         }
-    },
+    }
 
     get data()
     {
         return this._iterationsSamplers;
-    },
+    }
 
     get results()
     {
@@ -250,44 +252,44 @@
             return this._results[Strings.json.results.iterations];
         this._processData();
         return this._results[Strings.json.results.iterations];
-    },
+    }
 
     get options()
     {
         return this._options;
-    },
+    }
 
     get version()
     {
         return this._version;
-    },
+    }
 
-    _getResultsProperty: function(property)
+    _getResultsProperty(property)
     {
         if (this._results)
             return this._results[property];
         this._processData();
         return this._results[property];
-    },
+    }
 
     get score()
     {
         return this._getResultsProperty(Strings.json.score);
-    },
+    }
 
     get scoreLowerBound()
     {
         return this._getResultsProperty(Strings.json.scoreLowerBound);
-    },
+    }
 
     get scoreUpperBound()
     {
         return this._getResultsProperty(Strings.json.scoreUpperBound);
     }
-});
+}
 
-ResultsTable = Utilities.createClass(
-    function(element, headers)
+class ResultsTable {
+    constructor(element, headers)
     {
         this.element = element;
         this._headers = headers;
@@ -308,14 +310,14 @@ ResultsTable = Utilities.createClass(
         });
 
         this.clear();
-    }, {
+    }
 
-    clear: function()
+    clear()
     {
         this.element.textContent = "";
-    },
+    }
 
-    _addHeader: function()
+    _addHeader()
     {
         var thead = Utilities.createElement("thead", {}, this.element);
         var row = Utilities.createElement("tr", {}, thead);
@@ -330,22 +332,22 @@ ResultsTable = Utilities.createClass(
             if (header.children)
                 th.colSpan = header.children.length;
         });
-    },
+    }
 
-    _addBody: function()
+    _addBody()
     {
         this.tbody = Utilities.createElement("tbody", {}, this.element);
-    },
+    }
 
-    _addEmptyRow: function()
+    _addEmptyRow()
     {
         var row = Utilities.createElement("tr", {}, this.tbody);
         this._flattenedHeaders.forEach(function (header) {
             return Utilities.createElement("td", { class: "suites-separator" }, row);
         });
-    },
+    }
 
-    _addTest: function(testName, testResult, options)
+    _addTest(testName, testResult, options)
     {
         var row = Utilities.createElement("tr", {}, this.tbody);
 
@@ -361,9 +363,9 @@ ResultsTable = Utilities.createClass(
             } else
                 td.innerHTML = header.text(testResult);
         }, this);
-    },
+    }
 
-    _addIteration: function(iterationResult, iterationData, options)
+    _addIteration(iterationResult, iterationData, options)
     {
         var testsResults = iterationResult[Strings.json.results.tests];
         for (var suiteName in testsResults) {
@@ -373,9 +375,9 @@ ResultsTable = Utilities.createClass(
             for (var testName in suiteResult)
                 this._addTest(testName, suiteResult[testName], options, suiteData[testName]);
         }
-    },
+    }
 
-    showIterations: function(dashboard)
+    showIterations(dashboard)
     {
         this.clear();
         this._addHeader();
@@ -386,7 +388,7 @@ ResultsTable = Utilities.createClass(
             this._addIteration(iterationResult, dashboard.data[index], dashboard.options);
         }, this);
     }
-});
+}
 
 window.benchmarkRunnerClient = {
     iterationCount: 1,

--- a/MotionMark/tests/resources/math.js
+++ b/MotionMark/tests/resources/math.js
@@ -22,14 +22,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
-SimpleKalmanEstimator = Utilities.createSubclass(Experiment,
-    function(processError, measurementError) {
-        Experiment.call(this, false);
-        var error = .5 * (Math.sqrt(processError * processError + 4 * processError * measurementError) - processError);
-        this._gain = error / (error + measurementError);
-    }, {
 
-    sample: function(newMeasurement)
+class SimpleKalmanEstimator extends Experiment {
+    constructor(processError, measurementError)
+    {
+        super(false);
+        let error = .5 * (Math.sqrt(processError * processError + 4 * processError * measurementError) - processError);
+        this._gain = error / (error + measurementError);
+    }
+
+    sample(newMeasurement)
     {
         if (!this._initialized) {
             this._initialized = true;
@@ -38,18 +40,40 @@ SimpleKalmanEstimator = Utilities.createSubclass(Experiment,
         }
 
         this.estimate = this.estimate + this._gain * (newMeasurement - this.estimate);
-    },
+    }
 
-    reset: function()
+    reset()
     {
-        Experiment.prototype.reset.call(this);
+        super.reset();
         this._initialized = false;
         this.estimate = 0;
     }
-});
+}
 
-PIDController = Utilities.createClass(
-    function(ysp)
+class PIDController {
+
+    // This enum will be used to tell whether the system output (or the controller input)
+    // is moving towards the set-point or away from it.
+    yPositions = {
+        BEFORE_SETPOINT: 0,
+        AFTER_SETPOINT: 1
+    }
+
+    // The Ziegler-Nichols method for is used tuning the PID controller. The workflow of
+    // the tuning is split into four stages. The first two stages determine the values
+    // of the PID controller gains. During these two stages we return the proportional
+    // term only. The third stage is used to determine the min-max values of the
+    // saturation actuator. In the last stage back-calculation and tracking are applied
+    // to avoid integrator windup. During the last two stages, we return a PID control
+    // value.
+    stages = {
+        WARMING: 0,         // Increase the value of the Kp until the system output reaches ysp.
+        OVERSHOOT: 1,       // Measure the oscillation period and the overshoot value
+        UNDERSHOOT: 2,      // Return PID value and measure the undershoot value
+        SATURATE: 3         // Return PID value and apply back-calculation and tracking.
+    }
+
+    constructor(ysp)
     {
         this._ysp = ysp;
         this._out = 0;
@@ -59,17 +83,17 @@ PIDController = Utilities.createClass(
 
         this._eold = 0;
         this._I = 0;
-    }, {
+    }
 
     // Determines whether the current y is
     //  before ysp => (below ysp if ysp > y0) || (above ysp if ysp < y0)
     //  after ysp => (above ysp if ysp > y0) || (below ysp if ysp < y0)
-    _yPosition: function(y)
+    _yPosition(y)
     {
         return (y < this._ysp) == (this._y0 < this._ysp)
             ? PIDController.yPositions.BEFORE_SETPOINT
             : PIDController.yPositions.AFTER_SETPOINT;
-    },
+    }
 
     // Calculate the ultimate distance from y0 after time t. We want to move very
     // slowly at the beginning to see how adding few items to the test can affect
@@ -81,34 +105,34 @@ PIDController = Utilities.createClass(
     // The basic formula is: y = t^3
     // Change the formula to reach y=1 after 1000 ms: y = (t/1000)^3
     // Change the formula to reach y=(ysp - y0) after 1000 ms: y = (ysp - y0) * (t/1000)^3
-    _distanceUltimate: function(t)
+    _distanceUltimate(t)
     {
         return (this._ysp - this._y0) * Math.pow(t / 1000, 3);
-    },
+    }
 
     // Calculates the distance of y relative to y0. It also ensures we do not return
     // zero by returning a epsilon value in the same direction as ultimate distance.
-    _distance: function(y, du)
+    _distance(y, du)
     {
         const epsilon = 0.0001;
         var d  = y - this._y0;
         return du < 0 ? Math.min(d, -epsilon) : Math.max(d, epsilon);
-    },
+    }
 
     // Decides how much the proportional gain should be increased during the manual
     // gain stage. We choose to use the ratio of the ultimate distance to the current
     // distance as an indication of how much the system is responsive. We want
     // to keep the increment under control so it does not cause the system instability
     // So we choose to take the natural logarithm of this ratio.
-    _gainIncrement: function(t, y, e)
+    _gainIncrement(t, y, e)
     {
         var du = this._distanceUltimate(t);
         var d = this._distance(y, du);
         return Math.log(du / d) * 0.1;
-    },
+    }
 
     // Update the stage of the controller based on its current stage and the system output
-    _updateStage: function(y)
+    _updateStage(y)
     {
         var yPosition = this._yPosition(y);
 
@@ -128,17 +152,17 @@ PIDController = Utilities.createClass(
                 this._stage = PIDController.stages.SATURATE;
             break;
         }
-    },
+    }
 
     // Manual tuning is used before calculating the PID controller gains.
-    _tuneP: function(e)
+    _tuneP(e)
     {
         // The output is the proportional term only.
         return this._Kp * e;
-    },
+    }
 
     // PID tuning function. Kp, Ti and Td were already calculated
-    _tunePID: function(h, y, e)
+    _tunePID(h, y, e)
     {
         // Proportional term.
         var P = this._Kp * e;
@@ -152,10 +176,10 @@ PIDController = Utilities.createClass(
 
         // The ouput is a PID function.
        return P + this._I + D;
-    },
+    }
 
     // Apply different strategies for the tuning based on the stage of the controller.
-    _tune: function(t, h, y, e)
+    _tune(t, h, y, e)
     {
         switch (this._stage) {
         case PIDController.stages.WARMING:
@@ -211,10 +235,10 @@ PIDController = Utilities.createClass(
         }
 
         return 0;
-    },
+    }
 
     // Ensures the system does not fluctuates.
-    _saturate: function(v, e)
+    _saturate(v, e)
     {
         var u = v;
 
@@ -248,11 +272,11 @@ PIDController = Utilities.createClass(
 
         this._out += u;
         return u;
-    },
+    }
 
     // Called from the benchmark to tune its test. It uses Ziegler-Nichols method
     // to calculate the controller parameters. It then returns a PID tuning value.
-    tune: function(t, h, y)
+    tune(t, h, y)
     {
         this._updateStage(y);
 
@@ -266,27 +290,4 @@ PIDController = Utilities.createClass(
         // Apply back-calculation and tracking to avoid integrator windup
         return this._saturate(v, e);
     }
-});
-
-Utilities.extendObject(PIDController, {
-    // This enum will be used to tell whether the system output (or the controller input)
-    // is moving towards the set-point or away from it.
-    yPositions: {
-        BEFORE_SETPOINT: 0,
-        AFTER_SETPOINT: 1
-    },
-
-    // The Ziegler-Nichols method for is used tuning the PID controller. The workflow of
-    // the tuning is split into four stages. The first two stages determine the values
-    // of the PID controller gains. During these two stages we return the proportional
-    // term only. The third stage is used to determine the min-max values of the
-    // saturation actuator. In the last stage back-calculation and tracking are applied
-    // to avoid integrator windup. During the last two stages, we return a PID control
-    // value.
-    stages: {
-        WARMING: 0,         // Increase the value of the Kp until the system output reaches ysp.
-        OVERSHOOT: 1,       // Measure the oscillation period and the overshoot value
-        UNDERSHOOT: 2,      // Return PID value and measure the undershoot value
-        SATURATE: 3         // Return PID value and apply back-calculation and tracking.
-    }
-});
+}


### PR DESCRIPTION
Convert the harness code (and a bit of test code) to use JS class syntax, replacing `Utilities.createClass()` and `Utilities.createSubclass` with `class` and `extend`, fixing the formatting as appropriate.

Mostly mechanical, other than passing `window.location` to `Utilities.parseParameters` so it doesn't depend on the current window object, and fixing a `this` access in `calculateScore()`.

Some of these classes, like `Point`, are used in test code, so this may have some impact on test score.