### PR TITLE
Fix instability in the Design subtest

### DIFF
--- a/MotionMark/tests/core/design.html
+++ b/MotionMark/tests/core/design.html
@@ -28,12 +28,12 @@
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="../resources/stage.css">
     <style type="text/css">
-
         #stage {
             font-family: Helvetica;
             font-size: 52px;
             background-color: #313534;
         }
+
         @media (max-width: 900px) {
             #stage {
                 font-size: 40px;
@@ -56,14 +56,15 @@
         }
         table {
             position: relative;
+            top: 10%;
             width: 100%;
-            height: 100%;
+            height: 80%;
         }
         td {
             width: 33%;
         }
         tr {
-            height: 20%;
+            height: 12%;
         }
     </style>
 </head>


### PR DESCRIPTION
The Design subtest projects out copies of a `<table>` along a ray, where the step between copies is constant, so the longest distance increases with test complexity. At higher complexities, this results in clipping at the document boundary.

This clipping makes rendering additional copies cheap (since they are clipped out), which can result in the test computing artificially high complexities. This results in noisy or inaccurate test scores.

Fix by using a max distance computed from the height of the template element, and then spacing out the copies out to that distance. This ensures that all copies are inside the viewport. Adjust the layout, shrinking the table vertically a little so there's more space for copies above and below, where it tends to clip.