### PR TITLE
Fix iOS orientation detection

### DIFF
--- a/MotionMark/developer.html
+++ b/MotionMark/developer.html
@@ -124,8 +124,8 @@
                     Attempting to detect system frame rate: <span>0</span> FPS (in progress).
                 </p>
                 <div class="start-benchmark">
-                    <p class="hidden">Please rotate the device to orientation before starting.</p>
-                    <button id="run-benchmark" onclick="benchmarkController.startBenchmark()">Run benchmark</button>
+                    <p class="portrait-orientation-check hidden">Please rotate the device to orientation before starting.</p>
+                    <button id="start-button" onclick="benchmarkController.startBenchmark()">Run benchmark</button>
                 </div>
             </div>
         </section>

--- a/MotionMark/resources/debug-runner/debug-runner.js
+++ b/MotionMark/resources/debug-runner/debug-runner.js
@@ -601,7 +601,7 @@ Utilities.extendObject(window.benchmarkController, {
 
     updateStartButtonState: function()
     {
-        var startButton = document.getElementById("run-benchmark");
+        var startButton = document.getElementById("start-button");
         if ("isInLandscapeOrientation" in this && !this.isInLandscapeOrientation) {
             startButton.disabled = true;
             return;

--- a/MotionMark/resources/runner/motionmark.js
+++ b/MotionMark/resources/runner/motionmark.js
@@ -521,15 +521,16 @@ window.benchmarkController = {
     {
         benchmarkController.isInLandscapeOrientation = match.matches;
         if (match.matches)
-            document.querySelector(".start-benchmark p").classList.add("hidden");
+            document.querySelector(".portrait-orientation-check").classList.add("hidden");
         else
-            document.querySelector(".start-benchmark p").classList.remove("hidden");
+            document.querySelector(".portrait-orientation-check").classList.remove("hidden");
+
         benchmarkController.updateStartButtonState();
     },
 
     updateStartButtonState: function()
     {
-        document.getElementById("run-benchmark").disabled = !this.isInLandscapeOrientation;
+        document.getElementById("start-button").disabled = !this.isInLandscapeOrientation;
     },
 
     _startBenchmark: function(suites, options, frameContainerID)


### PR DESCRIPTION
developer.html and index.html used a different class name for the "Please rotate your device" tag, and the start button. This caused the JS to throw exceptions when running the orientation detection code.

So standardize these classes and ids between developer.html and index.html.