### PR TITLE
Use 'display' style as the default visibility property for Multiply

### DIFF
--- a/MotionMark/tests/core/resources/multiply.js
+++ b/MotionMark/tests/core/resources/multiply.js
@@ -33,8 +33,6 @@ var MultiplyStage = Utilities.createSubclass(Stage,
     }, {
 
     visibleCSS: [
-        ["visibility", "hidden", "visible"],
-        ["opacity", 0, 1],
         ["display", "none", "block"]
     ],
     totalRows: 68,


### PR DESCRIPTION
The Multiply test currently supports three different visibility property options: opacity, display, visibility. The default behavior with no option specified is to alternate between all three.

This change makes the 'display' property the default 'display'