### PR TITLE
Make the 'Paths' test workload more consistent

### DIFF
--- a/MotionMark/tests/core/resources/canvas-tests.js
+++ b/MotionMark/tests/core/resources/canvas-tests.js
@@ -110,7 +110,7 @@ CanvasLinePoint = Utilities.createClass(
         var colors = ["#101010", "#808080", "#c0c0c0", "#101010", "#808080", "#c0c0c0", "#e01040"];
         this.color = Stage.randomElementInArray(colors);
         this.width = Math.pow(Pseudo.random(), 5) * 20 + 1;
-        this.isSplit = Pseudo.random() > 0.95;
+        this.isSplit = Pseudo.random() > 0.5;
 
         var nextPoint;
         if (stage.objects.length)


### PR DESCRIPTION
This test fixes a gradual change in the number of points having isSplit=true from 5% to 50% of points by starting with 50% of points with isSplit=true.

Fixes #30