### PR TITLE
Increase the maximum complexity of Multiply to 68 rows

### DIFF
--- a/MotionMark/tests/core/resources/multiply.js
+++ b/MotionMark/tests/core/resources/multiply.js
@@ -35,7 +35,7 @@ var MultiplyStage = Utilities.createSubclass(Stage,
     visibleCSS: [
         ["display", "none", "block"]
     ],
-    totalRows: 55,
+    totalRows: 68,
 
     initialize: function(benchmark, options)
     {


### PR DESCRIPTION
On faster machines, the Multiply test can max out and stop producin useful results.

f5d127cff37d174599ab4e954a6ebfbb7787aeb8 increased the number of rows to 55, but testing shows that 68 is a better value to leave some headroom for future faster hardware and software.