### PR TITLE
Ignore mutation frames when scoring

### DIFF
--- a/MotionMark/resources/debug-runner/graph.js
+++ b/MotionMark/resources/debug-runner/graph.js
@@ -250,12 +250,14 @@ Utilities.extendObject(window.benchmarkController, {
             .attr("x1", function(d) { return xScale(d.complexity) - 3; })
             .attr("x2", function(d) { return xScale(d.complexity) + 3; })
             .attr("y1", function(d) { return yScale(d.frameLength) - 3; })
-            .attr("y2", function(d) { return yScale(d.frameLength) + 3; });
-        group.append("line")
+            .attr("y2", function(d) { return yScale(d.frameLength) + 3; })
+            .attr("class", function(d) { return d.frameType === "m" ? 'mutation' : 'animation'; });
+        group.append("line") 
             .attr("x1", function(d) { return xScale(d.complexity) - 3; })
             .attr("x2", function(d) { return xScale(d.complexity) + 3; })
             .attr("y1", function(d) { return yScale(d.frameLength) + 3; })
-            .attr("y2", function(d) { return yScale(d.frameLength) - 3; });
+            .attr("y2", function(d) { return yScale(d.frameLength) - 3; })
+            .attr("class", function(d) { return d.frameType === "m" ? 'mutation' : 'animation'; });
 
         // Cursor
         var cursorGroup = svg.append("g").attr("class", "cursor hidden");

--- a/MotionMark/resources/debug-runner/motionmark.css
+++ b/MotionMark/resources/debug-runner/motionmark.css
@@ -792,6 +792,10 @@ body.showing-test-graph header, body.showing-test-graph nav {
     stroke-width: 1px;
 }
 
+#complexity-graph .raw.series line.mutation {
+    stroke: rgba(255, 255, 255, .15);
+}
+
 #complexity-graph .raw.regression line {
     stroke: rgba(30, 96%, 86%, .6);
 }

--- a/MotionMark/resources/runner/motionmark.js
+++ b/MotionMark/resources/runner/motionmark.js
@@ -111,6 +111,7 @@
                 maxComplexity = series.getFieldInDatum(maxIndex, Strings.json.complexity);
             }
 
+            var frameTypeIndex = series.fieldMap[Strings.json.frameType];
             var complexityIndex = series.fieldMap[Strings.json.complexity];
             var frameLengthIndex = series.fieldMap[Strings.json.frameLength];
             var regressionOptions = { desiredFrameLength: desiredFrameLength };
@@ -118,7 +119,9 @@
                 regressionOptions.preferredProfile = profile;
 
             var regressionSamples = series.slice(minIndex, maxIndex + 1);
-            var regressionData = regressionSamples.data.map((sample) => [ sample[complexityIndex], sample[frameLengthIndex] ]);
+            var animationSamples = regressionSamples.data.filter((sample) => sample[frameTypeIndex] == Strings.json.animationFrameType);
+            var regressionData = animationSamples.map((sample) => [ sample[complexityIndex], sample[frameLengthIndex] ]);
+
             var regression = new Regression(regressionData, minIndex, maxIndex, regressionOptions);
             return {
                 minComplexity: minComplexity,

--- a/MotionMark/resources/strings.js
+++ b/MotionMark/resources/strings.js
@@ -44,10 +44,14 @@ var Strings = {
         samples: "samples",
         dataFieldMap: "dataFieldMap",
         controller: "controller",
+        frameType: "frameType",
         time: "time",
         complexity: "complexity",
         frameLength: "frameLength",
         smoothedFrameLength: "smoothedFrameLength",
+
+        mutationFrameType: "m",
+        animationFrameType: "a",
 
         result: "result",
         configuration: "configuration",


### PR DESCRIPTION
The RampController works by repeatedly changing the scene complexity, while measuring some number of animated frames at each complexity level. Currently, it tracks the duration of both the mutation frames, and the animation frames, and both contribute to the score.

This has two issues: first, it increases noise in the results because there are two types of frames, and the mutation frames generally take longer. This noise can throw off the regression computation used to compute the score.

Second, it's not the intent of this benchmark to measure DOM mutation performance. MotionMark is focused on animation, so it makes sense to only measure the animation frames.

This change ignores the mutation frames for the purpose of scoring.