### PR TITLE
The first frame of each ramp has an erroneously long frame duration

### DIFF
--- a/MotionMark/tests/resources/main.js
+++ b/MotionMark/tests/resources/main.js
@@ -165,6 +165,7 @@ Controller = Utilities.createClass(
                 this._frameLengthEstimator.sample(lastFrameLength);
                 frameLengthEstimate = this._frameLengthEstimator.estimate;
             }
+            this._sampler.record(timestamp, stage.complexity(), frameLengthEstimate);
         } else {
             this.registerFrameTime(lastFrameLength);
             if (this.intervalHasConcluded(timestamp)) {
@@ -174,13 +175,15 @@ Controller = Utilities.createClass(
                     this._frameLengthEstimator.sample(intervalAverageFrameLength);
                     frameLengthEstimate = this._frameLengthEstimator.estimate;
                 }
+                this._sampler.record(timestamp, stage.complexity(), frameLengthEstimate);
+
                 didFinishInterval = true;
                 this.didFinishInterval(timestamp, stage, intervalAverageFrameLength);
                 this._frameLengthEstimator.reset();
-            }
+            } else
+                this._sampler.record(timestamp, stage.complexity(), frameLengthEstimate);                
         }
 
-        this._sampler.record(timestamp, stage.complexity(), frameLengthEstimate);
         this.tune(timestamp, stage, lastFrameLength, didFinishInterval, intervalAverageFrameLength);
     },
 


### PR DESCRIPTION
`RampController.didFinishInterval()` is called before `Controller.update()` calls `this._sampler.record()`. This results in _rampStartIndex being off by one, pointing to the frame before start of the ramp, which in turn causes us to compute a long frame duration for this frame. This long frame feeds into the ramp controller regression computation, throwing it off slightly, and adding noise.

Fix by having `Controller.update()` call `_sampler.record()` before it calls `didFinishInterval()`, which requires calling `_sampler.record()` in each of the three code paths.