### PR TITLE
Simplify regression computation

### DIFF
--- a/MotionMark/resources/runner/motionmark.js
+++ b/MotionMark/resources/runner/motionmark.js
@@ -116,15 +116,15 @@
             var regressionOptions = { desiredFrameLength: desiredFrameLength };
             if (profile)
                 regressionOptions.preferredProfile = profile;
+
+            var regressionSamples = series.slice(minIndex, maxIndex + 1);
+            var regressionData = regressionSamples.data.map((sample) => [ sample[complexityIndex], sample[frameLengthIndex] ]);
+            var regression = new Regression(regressionData, minIndex, maxIndex, regressionOptions);
             return {
                 minComplexity: minComplexity,
                 maxComplexity: maxComplexity,
-                samples: series.slice(minIndex, maxIndex + 1),
-                regression: new Regression(
-                    series.data,
-                    function (data, i) { return data[i][complexityIndex]; },
-                    function (data, i) { return data[i][frameLengthIndex]; },
-                    minIndex, maxIndex, regressionOptions)
+                samples: regressionSamples,
+                regression: regression,
             };
         }
 

--- a/MotionMark/tests/resources/main.js
+++ b/MotionMark/tests/resources/main.js
@@ -36,7 +36,8 @@ Sampler = Utilities.createClass(
         this.sampleCount = 0;
     }, {
 
-    record: function() {
+    record: function()
+    {
         // Assume that arguments.length == this.samples.length
         for (var i = 0; i < arguments.length; i++) {
             this.samples[i][this.sampleCount] = arguments[i];
@@ -549,8 +550,11 @@ RampController = Utilities.createSubclass(Controller,
             return;
         }
 
-        var regression = new Regression(this._sampler.samples, this._getComplexity, this._getFrameLength,
-            this._sampler.sampleCount - 1, this._rampStartIndex, { desiredFrameLength: this.frameLengthDesired });
+        var regressionData = [];
+        for (var i = this._rampStartIndex; i < this._sampler.sampleCount; ++i)
+            regressionData.push([ this._getComplexity(this._sampler.samples, i), this._getFrameLength(this._sampler.samples, i) ]);
+
+        var regression = new Regression(regressionData, this._sampler.sampleCount - 1, this._rampStartIndex, { desiredFrameLength: this.frameLengthDesired });
         this._rampRegressions.push(regression);
 
         var frameLengthAtMaxComplexity = regression.valueAt(this._maximumComplexity);


### PR DESCRIPTION
The Regression class took index and function arguments to extract complexity and frame length from the supplied data, which makes it hard to adjust in the face of frame skipping which will come in a future patch.

Simplify by having the Regression class operate on a self-contained Array of x,y values (here, complexity and frame length). This also allows for removal of the complex logic that tracks if it's iterating forwards or backwards.

The two callers, in `RampController` and `calculateScore()`, build the input Array by copying out of their respective data stores. `new Array` is used for some performance gains.

There should be no behavior change.