### PR TITLE
Add webXR capability to MotionMark

### DIFF
--- a/MotionMark/resources/debug-runner/tests.js
+++ b/MotionMark/resources/debug-runner/tests.js
@@ -354,8 +354,24 @@ Suites.push(new Suite("Suits suite",
 Suites.push(new Suite("3D Graphics",
     [
         {
+            url: "3d/triangles-webgl.html?triangleSize=1.0",
+            name: "Triangles (WebGL, large)"
+        },
+        {
+            url: "3d/triangles-webgl.html?triangleSize=0.01",
+            name: "Triangles (WebGL, small)"
+        },
+        {
+            url: "3d/triangles-webgl.html?blended",
+            name: "Triangles (WebGL, blended)"
+        },
+        {
             url: "3d/triangles-webgl.html",
             name: "Triangles (WebGL)"
+        },
+        {
+            url: "3d/triangles-webgl.html?webxr",
+            name: "Triangles (WebXR)"
         },
         {
             url: "3d/triangles-webgpu.html",

--- a/MotionMark/tests/3d/resources/webgl.js
+++ b/MotionMark/tests/3d/resources/webgl.js
@@ -37,8 +37,12 @@ WebGLStage = Utilities.createSubclass(Stage,
 
             this._numTriangles = 0;
             this._bufferSize = 0;
-
-            this._gl = this.element.getContext("webgl");
+            this._testOptions = new URLSearchParams(document.location.search);
+            if(this._testOptions.has("webxr")) {
+                this._gl =  this.element.getContext('webgl2',{antialias:true, xrCompatible: true});
+            } else {
+                this._gl = this.element.getContext("webgl");
+            }
             var gl = this._gl;
 
             gl.clearColor(0, 0, 0, 1);
@@ -81,6 +85,10 @@ WebGLStage = Utilities.createSubclass(Stage,
 
             // Our program has two inputs. We have a single uniform "color",
             // and one vertex attribute "position".
+            if(this._testOptions.has("blended")) {
+                gl.enable(gl.BLEND);
+                gl.blendFunc(gl.SRC_COLOR, gl.DST_COLOR);
+            }
 
             gl.useProgram(program);
             this._uScale = gl.getUniformLocation(program, "scale");
@@ -96,27 +104,88 @@ WebGLStage = Utilities.createSubclass(Stage,
             this._aColor = gl.getAttribLocation(program, "color");
             gl.enableVertexAttribArray(this._aColor);
 
+            let s = 0.1;
+            if(this._testOptions.has("triangleSize")) {
+                s = parseFloat(this._testOptions.get("triangleSize"));
+            } 
             this._positionData = new Float32Array([
                 // x y z 1
-                   0,  0.1, 0, 1,
-                -0.1, -0.1, 0, 1,
-                 0.1, -0.1, 0, 1
+                0, s, 0, 1,
+                -s, -s, 0, 1,
+                s, -s, 0, 1
             ]);
             this._positionBuffer = gl.createBuffer();
             gl.bindBuffer(gl.ARRAY_BUFFER, this._positionBuffer);
             gl.bufferData(gl.ARRAY_BUFFER, this._positionData, gl.STATIC_DRAW);
 
+            const brightness = 0.1;
             this._colorData = new Float32Array([
-                1, 0, 0, 1,
-                0, 1, 0, 1,
-                0, 0, 1, 1
+                brightness, 0, 0, brightness,
+                0, brightness, 0, brightness,
+                0, 0, brightness, brightness
             ]);
             this._colorBuffer = gl.createBuffer();
             gl.bindBuffer(gl.ARRAY_BUFFER, this._colorBuffer);
             gl.bufferData(gl.ARRAY_BUFFER, this._colorData, gl.STATIC_DRAW);
 
+            if(this._testOptions.has("webxr")) {
+                this._benchmark._requestAnimationFrame = ()=>{};
+                var startButton = this._makeVRButton();
+            }
+
             this._resetIfNecessary();
         },
+
+        _makeVRButton: function() 
+        {
+            var button = document.createElement('div');
+            
+            Object.assign(button.style, {
+                position:'fixed',
+                top:0,
+                left:0,
+                width:'300px',
+                height:'30px',
+                fontSize:'1.5rem',
+                border:'thin solid white',
+                color:'white', 
+                backgroundColor:'black',
+                margin:'20px', 
+                textAlign:'center',
+                borderRadius:'20px'
+            });
+            
+            if(navigator.xr!=null) {
+                button.innerHTML = "Open webXR view";
+                button.addEventListener('click', clickEvent=>{
+                    this._launchXR();
+                });
+            } else button.innerHTML = "WebXR Not supported";
+                
+            document.body.appendChild(button);
+        },
+
+        _launchXR: function()
+        {
+            navigator.xr.requestSession('immersive-vr', {optionalFeatures: []})
+            .then(session=>{
+                var gl = this._gl;
+                session.addEventListener('end', e=>{
+                    this._requestAnimationFrame = (rafFunction,frame)=>
+                    window.requestAnimationFrame(rafFunction ,frame);
+                });
+                const baseLayer = new XRWebGLLayer(session, gl);
+                session.updateRenderState({ baseLayer });
+                session.requestReferenceSpace('local').then(refSpace=>{
+                    this.xrRefSpace = refSpace;
+                    this._benchmark._requestAnimationFrame = (rafFunction)=>{
+                        session.requestAnimationFrame((t,frame)=>rafFunction(t,frame));
+                    };
+                    this._benchmark._requestAnimationFrame(this._benchmark._animateLoop);
+                });
+            });
+        },
+
 
         _getFunctionSource: function(id)
         {
@@ -156,16 +225,56 @@ WebGLStage = Utilities.createSubclass(Stage,
             this._resetIfNecessary();
         },
 
-        animate: function(timeDelta)
+        animate: function(timeDelta, xrFrame)
+        {
+            if(xrFrame) {
+                this.animateXR(timeDelta, xrFrame); 
+            } else {
+                this.animate2D(timeDelta);
+            }
+        },
+
+        animate2D: function(timeDelta)
         {
             var gl = this._gl;
 
-            gl.clear(gl.COLOR_BUFFER_BIT);
+            
+            if (!this._startTime)
+            this._startTime = Stage.dateCounterValue(1000);
+            var elapsedTime = Stage.dateCounterValue(1000) - this._startTime;
+            gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+            
+           this._animateInternal(elapsedTime);
+
+        },
+
+        animateXR: function (t,frame) {
+            var gl = this._gl;
 
             if (!this._startTime)
-                this._startTime = Stage.dateCounterValue(1000);
+            this._startTime = Stage.dateCounterValue(1000);
             var elapsedTime = Stage.dateCounterValue(1000) - this._startTime;
+            gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
+
+            let pose = frame.getViewerPose(this.xrRefSpace);
+            let glLayer = frame.session.renderState.baseLayer;
+
+            if(pose) {
+                gl.bindFramebuffer(gl.FRAMEBUFFER, glLayer.framebuffer);
+
+            for (let view of pose.views) {
+                let viewport = glLayer.getViewport(view);
+                gl.viewport(viewport.x, viewport.y,
+                viewport.width, viewport.height);
+                this._animateInternal(elapsedTime);
+            }  
+        }
+    },
+
+        _animateInternal: function (elapsedTime) {
+            let gl = this._gl;
+            
             for (var i = 0; i < this._numTriangles; ++i) {
 
                 this._uniformData[i * 6 + 1] = elapsedTime;

--- a/MotionMark/tests/resources/main.js
+++ b/MotionMark/tests/resources/main.js
@@ -891,6 +891,8 @@ Benchmark = Utilities.createClass(
         this._firstFrameMinimumLength = options["first-frame-minimum-length"];
 
         this._stage = stage;
+        this._requestAnimationFrame = rafFunction=> window.requestAnimationFrame(rafFunction)
+
         this._stage.initialize(this, options);
 
         switch (options["time-measurement"])
@@ -960,7 +962,7 @@ Benchmark = Utilities.createClass(
         return promise;
     },
 
-    _animateLoop: function(timestamp)
+    _animateLoop: function(timestamp,frame)
     {
         timestamp = (this._getTimestamp && this._getTimestamp()) || timestamp;
         this._currentTimestamp = timestamp;
@@ -984,15 +986,15 @@ Benchmark = Utilities.createClass(
                 }
             }
 
-            this._stage.animate(0);
+            this._stage.animate(0,frame);
             ++this._frameCount;
-            requestAnimationFrame(this._animateLoop);
+            this._requestAnimationFrame(this._animateLoop);
             return;
         }
 
         this._controller.update(timestamp, this._stage);
-        this._stage.animate(timestamp - this._previousTimestamp);
+        this._stage.animate(timestamp - this._previousTimestamp,frame);
         this._previousTimestamp = timestamp;
-        requestAnimationFrame(this._animateLoop);
+        this._requestAnimationFrame(this._animateLoop);
     }
 });


### PR DESCRIPTION
Update the main harness to pass through a frame object where extant, Update the main harness to use an internally-stored `requestAnimationFrame` to be rerouted in the case of webXR tests, Add the webXR capabilities to the base webGL test, add examples to the developer test harness of leveraging the new parameters.
