### PR TITLE
Support WebXR in a self-contained way

### DIFF
--- a/MotionMark/resources/debug-runner/tests.js
+++ b/MotionMark/resources/debug-runner/tests.js
@@ -358,6 +358,10 @@ Suites.push(new Suite("3D Graphics",
             name: "Triangles (WebGL)"
         },
         {
+            url: "3d/triangles-webgl.html?webxr=true",
+            name: "Triangles (WebXR)"
+        },
+        {
             url: "3d/triangles-webgpu.html",
             name: "Triangles (WebGPU)"
         },


### PR DESCRIPTION
Because of WebXR's history as targeting a separate display device (in the case of a desktop computer connected to an HMD), it requires a separate `requestAnimationFrame` handler to manage the frame rate - even in modern, standalone webXR devices. This update localizes the changes required to `webgl.js` by dynamically patching the containing Benchmark instance, and adding only the additional parameters required to do the current webGL tests within webXR.