### PR TITLE
Updates scoring to use max-complexity in certain case

### DIFF
--- a/MotionMark/resources/runner/motionmark.js
+++ b/MotionMark/resources/runner/motionmark.js
@@ -196,6 +196,15 @@
 
                 var resample = new SampleData(regressionResult.samples.fieldMap, resampleData);
                 var bootstrapRegressionResult = findRegression(resample, predominantProfile);
+		if (bootstrapRegressionResult.regression.t2 < 0) {
+                  // A positive slope means the frame rate decreased with increased complexity (which is the expected
+                  // benavior). OTOH, a negative slope means the framerate increased as the complexity increased. This
+                  // likely means the max complexity needs to be increased. None-the-less, if the slope is negative use
+                  // the max-complexity as the computed complexity (intersection of the two lines) does not tell us
+                  // the point when the browser could not handle the complexity, rather it tells us when the framerate
+                  // increased.
+                  return bootstrapRegressionResult.maxComplexity;
+                }
                 return bootstrapRegressionResult.regression.complexity;
             }, .8);
 


### PR DESCRIPTION
This changes the scoring to use the max complexity if the slope of the line is negative. From the comment:
 // A positive slope means the frame rate decreased with increased complexity (which is the expected
// benavior). OTOH, a negative slope means the framerate increased as the complexity increased. This
// likely means the max complexity needs to be increased. None-the-less, if the slope is negative use
// the max-complexity as the computed complexity (intersection of the two lines) does not tell us
// the point when the browser could not handle the complexity, rather it tells us when the framerate
// increased.