### PR TITLE
Increases complexity of Multiply

### DIFF
--- a/MotionMark/tests/core/resources/multiply.js
+++ b/MotionMark/tests/core/resources/multiply.js
@@ -35,7 +35,7 @@ var MultiplyStage = Utilities.createSubclass(Stage,
     visibleCSS: [
         ["display", "none", "block"]
     ],
-    totalRows: 68,
+    totalRows: 72,
 
     initialize: function(benchmark, options)
     {


### PR DESCRIPTION
As Chrome can handle the max complexity on M3 devices, this increases the complexity to the next value that results in an increase.