### PR TITLE
Add a way to write Unit Tests.

### DIFF
--- a/MotionMark/unit-tests/run-unit-tests.html
+++ b/MotionMark/unit-tests/run-unit-tests.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no">
+    <title>MotionMark Unit Tests</title>
+
+    <script src="../resources/strings.js"></script>
+    <script src="../resources/extensions.js"></script>
+    <script src="../resources/statistics.js"></script>
+
+    <script src="../resources/runner/tests.js"></script>
+    <script src="../resources/debug-runner/tests.js"></script>
+
+    <script src="../resources/runner/benchmark-runner.js"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/expect.js/0.2.0/expect.min.js"></script>
+    <script src="https://unpkg.com/mocha/mocha.js"></script>
+
+    <link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />
+    <link rel="stylesheet" href="../resources/runner/motionmark.css">
+    <link rel="stylesheet" href="../resources/debug-runner/motionmark.css">
+
+    <style>
+        body {
+            -webkit-user-select: text;
+            cursor: auto;
+            margin: 8px;
+        }
+
+        #mocha {
+            margin: 20px 50px;
+        }
+    </style>
+</head>
+<body>
+    <h1>MotionMark Unit Tests</h1>
+    <div id="mocha"></div>
+
+    <script class="mocha-init">
+        mocha.setup('bdd');
+        mocha.checkLeaks();
+    </script>
+
+    <script src="tests/test-random.js"></script>
+    <script src="tests/test-statistics.js"></script>
+
+    <script class="mocha-exec">
+        mocha.run();
+    </script>
+</body>
+</html>

--- a/MotionMark/unit-tests/tests/test-random.js
+++ b/MotionMark/unit-tests/tests/test-random.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+describe('Random', function() {
+    it('Check random sequence', function() {
+        Pseudo.resetRandomSeed();
+        expect(Pseudo.randomSeed).to.be(49734321);
+        expect(Pseudo.random().toFixed(6)).to.be('0.987282');
+        expect(Pseudo.random().toFixed(6)).to.be('0.348803');
+        expect(Pseudo.random().toFixed(6)).to.be('0.563193');
+    });
+});

--- a/MotionMark/unit-tests/tests/test-statistics.js
+++ b/MotionMark/unit-tests/tests/test-statistics.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+describe('Statistics', function() {
+    describe('sampleMean()', function() {
+        it('sampleMean should compute the mean', function() {
+            expect(Statistics.sampleMean(10, 100)).to.be(10);
+        });
+
+        it('sampleMean with zero samples should be zero', function() {
+            expect(Statistics.sampleMean(0, 100)).to.be(0);
+        });
+    });
+
+    describe('geometricMean()', function() {
+        it('geometricMean should compute the geometric mean', function() {
+            const values = [6, 2, 3, 5];
+            const result = Statistics.geometricMean(values).toFixed(3);
+            expect(result).to.be('3.663')
+        });
+
+        it('geometricMean with a zero should compute to zero', function() {
+            const values = [6, 2, 0, 5];
+            const result = Statistics.geometricMean(values).toFixed(3);
+            expect(result).to.be('0.000')
+        });
+    });
+});


### PR DESCRIPTION
Add some Mocha[1]-based tests for Pseudo and Statistics as initial examples.

They are run by loading `unit-tests/run-unit-tests.html` in the browser.

[1] [https://mochajs.org/](https://mochajs.org/)