### PR TITLE
Replace SimplePromise with native Promises

### DIFF
--- a/MotionMark/resources/extensions.js
+++ b/MotionMark/resources/extensions.js
@@ -434,44 +434,6 @@ class UnitBezier {
     }
 }
 
-class SimplePromise {
-    constructor()
-    {
-        this._chainedPromise = null;
-        this._callback = null;
-    }
-
-    then (callback)
-    {
-        if (this._callback)
-            throw "SimplePromise doesn't support multiple calls to then";
-
-        this._callback = callback;
-        this._chainedPromise = new SimplePromise;
-
-        if (this._resolved)
-            this.resolve(this._resolvedValue);
-
-        return this._chainedPromise;
-    }
-
-    resolve (value)
-    {
-        if (!this._callback) {
-            this._resolved = true;
-            this._resolvedValue = value;
-            return;
-        }
-
-        var result = this._callback(value);
-        if (result instanceof SimplePromise) {
-            var chainedPromise = this._chainedPromise;
-            result.then(function (result) { chainedPromise.resolve(result); });
-        } else
-            this._chainedPromise.resolve(result);
-    }
-}
-
 class Heap {
     
     static createMinHeap(maxSize)

--- a/MotionMark/tests/3d/resources/webgl.js
+++ b/MotionMark/tests/3d/resources/webgl.js
@@ -24,10 +24,9 @@
  */
 
 class WebGLStage extends Stage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
-
+        await super.initialize(benchmark, options);
         this._numTriangles = 0;
         this._bufferSize = 0;
 

--- a/MotionMark/tests/bouncing-particles/resources/bouncing-canvas-images.js
+++ b/MotionMark/tests/bouncing-particles/resources/bouncing-canvas-images.js
@@ -40,10 +40,10 @@ class BouncingCanvasImage extends BouncingCanvasParticle {
 }
 
 class BouncingCanvasImagesStage extends BouncingCanvasParticlesStage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
-        var imageSrc = options["imageSrc"] || "../resources/yin-yang.svg";
+        await super.initialize(benchmark, options);
+        const imageSrc = options["imageSrc"] || "../resources/yin-yang.svg";
         this.imageElement = document.querySelector(".hidden[src=\"" + imageSrc + "\"]");
     }
 

--- a/MotionMark/tests/bouncing-particles/resources/bouncing-canvas-particles.js
+++ b/MotionMark/tests/bouncing-particles/resources/bouncing-canvas-particles.js
@@ -93,9 +93,9 @@ class BouncingCanvasParticle extends BouncingParticle {
 }
 
 class BouncingCanvasParticlesStage extends BouncingParticlesStage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.context = this.element.getContext("2d");
     }
 

--- a/MotionMark/tests/bouncing-particles/resources/bouncing-canvas-shapes.js
+++ b/MotionMark/tests/bouncing-particles/resources/bouncing-canvas-shapes.js
@@ -86,9 +86,9 @@ class BouncingCanvasShapesStage extends BouncingCanvasParticlesStage {
         super();
     }
 
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.parseShapeParameters(options);
     }
 

--- a/MotionMark/tests/bouncing-particles/resources/bouncing-css-images.js
+++ b/MotionMark/tests/bouncing-particles/resources/bouncing-css-images.js
@@ -50,9 +50,9 @@ class BouncingCssImage extends BouncingParticle {
 }
 
 class BouncingCssImagesStage extends BouncingParticlesStage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.imageSrc = options["imageSrc"] || "../resources/yin-yang.svg";
     }
 

--- a/MotionMark/tests/bouncing-particles/resources/bouncing-css-shapes.js
+++ b/MotionMark/tests/bouncing-particles/resources/bouncing-css-shapes.js
@@ -75,9 +75,9 @@ class BouncingCssShape extends BouncingParticle {
 }
 
 class BouncingCssShapesStage extends BouncingParticlesStage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.parseShapeParameters(options);
     }
 

--- a/MotionMark/tests/bouncing-particles/resources/bouncing-particles.js
+++ b/MotionMark/tests/bouncing-particles/resources/bouncing-particles.js
@@ -96,9 +96,9 @@ class BouncingParticlesStage extends Stage {
         this.particles = [];
     }
 
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.particleSize = new Point(parseInt(options["particleWidth"]) || 10, parseInt(options["particleHeight"]) || 10);
         this.maxVelocity = Math.max(parseInt(options["maxVelocity"]) || 500, 100);
     }

--- a/MotionMark/tests/bouncing-particles/resources/bouncing-svg-images.js
+++ b/MotionMark/tests/bouncing-particles/resources/bouncing-svg-images.js
@@ -33,12 +33,12 @@ class BouncingSvgImage extends BouncingSvgParticle {
         this.element = Utilities.createSVGElement("image", attrs, xlinkAttrs, stage.element);
         this._move();
     }
-)
+}
 
 class BouncingSvgImagesStage extends BouncingSvgParticlesStage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.imageSrc = options["imageSrc"] || "../resources/yin-yang.svg";
     }
 

--- a/MotionMark/tests/bouncing-particles/resources/bouncing-svg-shapes.js
+++ b/MotionMark/tests/bouncing-particles/resources/bouncing-svg-shapes.js
@@ -69,9 +69,9 @@ class BouncingSvgShape extends BouncingSvgParticle {
 }
 
 class BouncingSvgShapesStage extends BouncingSvgParticlesStage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.parseShapeParameters(options);
         this._gradientsCount = 0;
     }

--- a/MotionMark/tests/core/resources/canvas-stage.js
+++ b/MotionMark/tests/core/resources/canvas-stage.js
@@ -32,9 +32,9 @@ class CanvasStage extends Stage {
         this.offsetIndex = 0;
     }
 
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.context = this.element.getContext("2d");
     }
 

--- a/MotionMark/tests/core/resources/canvas-tests.js
+++ b/MotionMark/tests/core/resources/canvas-tests.js
@@ -205,9 +205,9 @@ class CanvasLineSegmentStage extends CanvasStage {
         super(CanvasLineSegment);
     }
 
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.context.lineCap = options["lineCap"] || "butt";
         this.lineMinimum = 20;
         this.lineLengthMaximum = 40;
@@ -271,9 +271,9 @@ class CanvasLinePathStage extends CanvasStage {
         super([CanvasLinePoint, CanvasLinePoint, CanvasQuadraticSegment, CanvasBezierSegment]);
     }
 
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.context.lineJoin = options["lineJoin"] || "bevel";
         this.context.lineCap = options["lineCap"] || "butt";
     }

--- a/MotionMark/tests/core/resources/design.js
+++ b/MotionMark/tests/core/resources/design.js
@@ -44,12 +44,11 @@ class TextStage extends Stage {
         this._offsetIndex = 0;
     }
     
-    initialize(benchmark)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark);
-
+        await super.initialize(benchmark, options);
         this._template = document.getElementById("template");
-        
+    
         const templateSize = GeometryHelpers.elementClientSize(this._template);
         this._offset = this.size.subtract(templateSize).multiply(.5);
         this._maxOffset = templateSize.height / 4;

--- a/MotionMark/tests/core/resources/focus.js
+++ b/MotionMark/tests/core/resources/focus.js
@@ -87,10 +87,9 @@ class FocusElement {
 }
 
 class FocusStage extends Stage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
-
+        await super.initialize(benchmark, options);
         this._testElements = [];
         this._offsetIndex = 0;
         this.focalPoint = 0.5;

--- a/MotionMark/tests/core/resources/multiply.js
+++ b/MotionMark/tests/core/resources/multiply.js
@@ -34,23 +34,24 @@ class MultiplyStage extends Stage {
         this._offsetIndex = 0;
     }
 
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
-        var tileSize = Math.round(this.size.height / MultiplyStage.totalRows);
+        await super.initialize(benchmark, options);
+
+        const tileSize = Math.round(this.size.height / MultiplyStage.totalRows);
         if (options.visibleCSS)
             MultiplyStage.visibleCSS = options.visibleCSS;
 
         // Fill the scene with elements
-        var x = Math.round((this.size.width - tileSize) / 2);
-        var y = Math.round((this.size.height - tileSize) / 2);
-        var tileStride = tileSize;
-        var direction = 0;
-        var spiralCounter = 2;
-        var nextIndex = 1;
-        var maxSide = Math.floor(y / tileStride) * 2 + 1;
+        let x = Math.round((this.size.width - tileSize) / 2);
+        let y = Math.round((this.size.height - tileSize) / 2);
+        const tileStride = tileSize;
+        let direction = 0;
+        let spiralCounter = 2;
+        let nextIndex = 1;
+        const maxSide = Math.floor(y / tileStride) * 2 + 1;
         this._centerSpiralCount = maxSide * maxSide;
-        for (var i = 0; i < this._centerSpiralCount; ++i) {
+        for (let i = 0; i < this._centerSpiralCount; ++i) {
             this._addTile(x, y, tileSize, Stage.randomInt(0, 359));
 
             if (i == nextIndex) {
@@ -69,9 +70,9 @@ class MultiplyStage extends Stage {
         }
 
         this._sidePanelCount = maxSide * Math.floor((this.size.width - x) / tileStride) * 2;
-        for (var i = 0; i < this._sidePanelCount; ++i) {
-            var sideX = x + Math.floor(Math.floor(i / maxSide) / 2) * tileStride;
-            var sideY = y - tileStride * (i % maxSide);
+        for (let i = 0; i < this._sidePanelCount; ++i) {
+            let sideX = x + Math.floor(Math.floor(i / maxSide) / 2) * tileStride;
+            let sideY = y - tileStride * (i % maxSide);
 
             if (Math.floor(i / maxSide) % 2 == 1)
                 sideX = this.size.width - sideX - tileSize + 1;
@@ -81,16 +82,16 @@ class MultiplyStage extends Stage {
 
     _addTile(x, y, tileSize, rotateDeg)
     {
-        var tile = Utilities.createElement("div", { class: "div-" + Stage.randomInt(0,6) }, this.element);
-        var halfTileSize = tileSize / 2;
+        const tile = Utilities.createElement("div", { class: "div-" + Stage.randomInt(0,6) }, this.element);
+        const halfTileSize = tileSize / 2;
         tile.style.left = x + 'px';
         tile.style.top = y + 'px';
         tile.style.width = tileSize + 'px';
         tile.style.height = tileSize + 'px';
-        var visibleCSS = MultiplyStage.visibleCSS[this.tiles.length % MultiplyStage.visibleCSS.length];
+        const visibleCSS = MultiplyStage.visibleCSS[this.tiles.length % MultiplyStage.visibleCSS.length];
         tile.style[visibleCSS[0]] = visibleCSS[1];
 
-        var distance = 1 / tileSize * this.size.multiply(0.5).subtract(new Point(x + halfTileSize, y + halfTileSize)).length();
+        const distance = 1 / tileSize * this.size.multiply(0.5).subtract(new Point(x + halfTileSize, y + halfTileSize)).length();
         this.tiles.push({
             element: tile,
             rotate: rotateDeg,

--- a/MotionMark/tests/core/resources/suits.js
+++ b/MotionMark/tests/core/resources/suits.js
@@ -98,9 +98,9 @@ class SuitsParticle extends Particle {
 }
 
 class SuitsStage extends ParticlesStage {
-    initialize(benchmark)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark);
+        await super.initialize(benchmark, options);
         this.emissionSpin = Stage.random(0, 3);
         this.emitSteps = Stage.randomInt(4, 6);
         this.emitLocation = [

--- a/MotionMark/tests/dom/resources/compositing-transforms.js
+++ b/MotionMark/tests/dom/resources/compositing-transforms.js
@@ -53,10 +53,9 @@ class BouncingCompositedImage extends BouncingParticle {
 }
 
 class CompositingTransformsStage extends BouncingParticlesStage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
-
+        await super.initialize(benchmark, options);
         this.imageSrc = options["imageSrc"] || "../resources/yin-yang.svg";
         this.useFilters = options["filters"] == "yes";
     }

--- a/MotionMark/tests/dom/resources/dom-particles.js
+++ b/MotionMark/tests/dom/resources/dom-particles.js
@@ -59,9 +59,9 @@ class DOMParticle extends Particle {
 }
 
 class DOMParticleStage extends ParticlesStage {
-    initialize(benchmark)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark);
+        await super.initialize(benchmark, options);
         this.emissionSpin = Stage.random(0, 3);
         this.emitSteps = Stage.randomInt(4, 6);
         this.emitLocation = [

--- a/MotionMark/tests/dom/resources/focus.js
+++ b/MotionMark/tests/dom/resources/focus.js
@@ -92,10 +92,9 @@ class FocusStage extends Stage {
     static maxBlurValue = 15;
     static maxCenterObjectBlurValue = 5;
     
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
-
+        await super.initialize(benchmark, options);
         this._testElements = [];
         this._focalPoint = 0.5;
         this._offsetIndex = 0;

--- a/MotionMark/tests/resources/stage.js
+++ b/MotionMark/tests/resources/stage.js
@@ -62,7 +62,7 @@ class Stage {
     {
     }
 
-    initialize(benchmark)
+    async initialize(benchmark)
     {
         this._benchmark = benchmark;
         this._element = document.getElementById("stage");

--- a/MotionMark/tests/simple/resources/simple-canvas-paths.js
+++ b/MotionMark/tests/simple/resources/simple-canvas-paths.js
@@ -206,9 +206,9 @@ class CanvasArcSegment {
 }
 
 class CanvasArcSegmentFill extends CanvasArcSegment {
-    constructor()
+    constructor(stage)
     {
-        super();
+        super(stage);
     }
     
     draw(context)
@@ -372,9 +372,9 @@ class CanvasLineSegmentStage extends SimpleCanvasStage {
         super(CanvasLineSegment);
     }
 
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.context.lineCap = options["lineCap"] || "butt";
     }
 }
@@ -385,9 +385,9 @@ class CanvasLinePathStage extends SimpleCanvasPathStrokeStage {
         super(CanvasLinePoint);
     }
 
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.context.lineJoin = options["lineJoin"] || "bevel";
     }
 }
@@ -399,9 +399,9 @@ class CanvasLineDashStage extends SimpleCanvasStage {
         this._step = 0;
     }
 
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.context.setLineDash([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         this.context.lineWidth = 1;
         this.context.strokeStyle = "#000";

--- a/MotionMark/tests/simple/resources/tiled-canvas-image.js
+++ b/MotionMark/tests/simple/resources/tiled-canvas-image.js
@@ -48,9 +48,9 @@ class TiledCanvasImageStage extends Stage {
         super();
     }
 
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.context = this.element.getContext("2d");
         this._setupTiles();
     }

--- a/MotionMark/tests/template/resources/template-canvas.js
+++ b/MotionMark/tests/template/resources/template-canvas.js
@@ -53,12 +53,12 @@ class TemplateCanvasObject
 }
 
 class TemplateCanvasStage extends Stage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
+        await super.initialize(benchmark, options);
         this.context = this.element.getContext("2d");
-
         // Define a collection for your objects.
+        // await any async work (e.g. image loading).
     }
 
     tune(count)
@@ -87,21 +87,6 @@ class TemplateCanvasBenchmark extends Benchmark {
     constructor(options)
     {
         super(new TemplateCanvasStage(), options);
-    }
-
-    // Override this function if the benchmark needs to wait for resources to be
-    // loaded.
-    //
-    // Default implementation returns a resolved promise, so that the benchmark
-    // benchmark starts right away. Here's an example where we're waiting 5
-    // seconds before starting the benchmark.
-    waitUntilReady()
-    {
-        var promise = new SimplePromise;
-        window.setTimeout(function() {
-            promise.resolve();
-        }, 5000);
-        return promise;
     }
 }
 

--- a/MotionMark/tests/template/resources/template-css.js
+++ b/MotionMark/tests/template/resources/template-css.js
@@ -24,10 +24,9 @@
  */
 
 class TemplateCssStage extends Stage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
-
+        await super.initialize(benchmark, options);
         // Do initialization here.
     }
 

--- a/MotionMark/tests/template/resources/template-svg.js
+++ b/MotionMark/tests/template/resources/template-svg.js
@@ -24,10 +24,9 @@
  */
 
 class TemplateSvgStage extends Stage {
-    initialize(benchmark, options)
+    async initialize(benchmark, options)
     {
-        super.initialize(benchmark, options);
-
+        await super.initialize(benchmark, options);
         // Do initialization here.
     }
 


### PR DESCRIPTION
This PR replaces usage of SimplePromise with native Promises. The API shape is slightly different, requiring some logic changes.

The biggest change is that `Stage.initialize()` now returns a Promise, which lets us remove `waitUntilRead()`. When a Stage subclass implements `initialize()`, it can chain its own Promise with the one returned by the base class.

Run initialization and steps are also controlled by a series of chained promises in `_runBenchmarkAndRecordResults()`.

modified:   MotionMark/resources/debug-runner/debug-runner.js: Fix a bug that broke clicking some controls.
modified:   MotionMark/resources/extensions.js
modified:   MotionMark/resources/runner/benchmark-runner.js
modified:   MotionMark/resources/runner/motionmark.js
modified:   MotionMark/tests/3d/resources/webgl.js
modified:   MotionMark/tests/3d/resources/webgpu.js
modified:   MotionMark/tests/bouncing-particles/resources/bouncing-canvas-images.js
modified:   MotionMark/tests/bouncing-particles/resources/bouncing-canvas-particles.js
modified:   MotionMark/tests/bouncing-particles/resources/bouncing-canvas-shapes.js
modified:   MotionMark/tests/bouncing-particles/resources/bouncing-css-images.js
modified:   MotionMark/tests/bouncing-particles/resources/bouncing-css-shapes.js
modified:   MotionMark/tests/bouncing-particles/resources/bouncing-particles.js
modified:   MotionMark/tests/bouncing-particles/resources/bouncing-svg-images.js
modified:   MotionMark/tests/bouncing-particles/resources/bouncing-svg-shapes.js
modified:   MotionMark/tests/bouncing-particles/resources/bouncing-tagged-images.js
modified:   MotionMark/tests/core/resources/canvas-stage.js
modified:   MotionMark/tests/core/resources/canvas-tests.js
modified:   MotionMark/tests/core/resources/design.js
modified:   MotionMark/tests/core/resources/focus.js
modified:   MotionMark/tests/core/resources/image-data.js
modified:   MotionMark/tests/core/resources/leaves.js
modified:   MotionMark/tests/core/resources/multiply.js
modified:   MotionMark/tests/core/resources/suits.js
modified:   MotionMark/tests/dom/resources/compositing-transforms.js
modified:   MotionMark/tests/dom/resources/dom-particles.js
modified:   MotionMark/tests/dom/resources/focus.js
modified:   MotionMark/tests/resources/main.js
modified:   MotionMark/tests/simple/resources/simple-canvas-paths.js
modified:   MotionMark/tests/simple/resources/tiled-canvas-image.js
modified:   MotionMark/tests/template/resources/template-canvas.js
modified:   MotionMark/tests/template/resources/template-css.js
modified:   MotionMark/tests/template/resources/template-svg.js