### PR TITLE
Windowed score functions

### DIFF
--- a/MotionMark/developer.html
+++ b/MotionMark/developer.html
@@ -100,6 +100,15 @@
                                     </ul>
                                 </li>
                                 <li>
+                                    <h3>Score profile:</h3>
+                                    <ul>
+                                        <li><label><input name="score-profile" type="radio" value="slope" checked> Slope</label></li>
+                                        <li><label><input name="score-profile" type="radio" value="flat"> Flat</label></li>
+                                        <li><label><input name="score-profile" type="radio" value="window"> Windowed</label></li>
+                                        <li><label><input name="score-profile" type="radio" value="window-strict"> Windowed Strict</label></li>
+                                    </ul>
+                                </li>
+                                <li>
                                     <label>System frame rate: <input type="number" id="system-frame-rate" value="60"> FPS</label><br>
                                     <label>Target frame rate: <input type="number" id="frame-rate" value="60"> FPS</label>
                                 </li>

--- a/MotionMark/resources/debug-runner/debug-runner.js
+++ b/MotionMark/resources/debug-runner/debug-runner.js
@@ -214,7 +214,7 @@ window.optionsManager = new class OptionsManager {
                 options[name] = formElement.checked;
             else if (type == "radio") {
                 var radios = formElements[name];
-                if (radios.constructor === HTMLCollection) {
+                if (radios.constructor === RadioNodeList || radios.constructor === HTMLCollection) {
                     for (var j = 0; j < radios.length; ++j) {
                         var radio = radios[j];
                         if (radio.checked) {
@@ -657,7 +657,8 @@ class DebugBenchmarkController extends BenchmarkController {
     startBenchmark()
     {
         benchmarkController.determineCanvasSize();
-        benchmarkController.options = Utilities.mergeObjects(this.benchmarkDefaultParameters, optionsManager.updateLocalStorageFromUI());
+        const optionsFromUI = optionsManager.updateLocalStorageFromUI();
+        benchmarkController.options = Utilities.mergeObjects(this.benchmarkDefaultParameters, optionsFromUI);
         benchmarkController.suites = suitesManager.updateLocalStorageFromUI();
         this._startBenchmark(benchmarkController.suites, benchmarkController.options, "running-test");
     }

--- a/MotionMark/resources/runner/results.js
+++ b/MotionMark/resources/runner/results.js
@@ -180,6 +180,7 @@ class ScoreCalculator {
 
             const frameTypeIndex = series.fieldMap[Strings.json.frameType];
             const complexityIndex = series.fieldMap[complexityKey];
+            const frameTimeIndex = series.fieldMap[Strings.json.time];
             const frameLengthIndex = series.fieldMap[Strings.json.frameLength];
             const regressionOptions = { desiredFrameLength: desiredFrameLength };
             if (profile)
@@ -187,7 +188,7 @@ class ScoreCalculator {
 
             const regressionSamples = series.slice(minIndex, maxIndex + 1);
             const animationSamples = regressionSamples.data.filter((sample) => sample[frameTypeIndex] == Strings.json.animationFrameType);
-            const regressionData = animationSamples.map((sample) => [ sample[complexityIndex], sample[frameLengthIndex] ]);
+            const regressionData = animationSamples.map((sample) => [ sample[complexityIndex], sample[frameLengthIndex], sample[frameTimeIndex] ]);
 
             const regression = new Regression(regressionData, minIndex, maxIndex, regressionOptions);
             return {
@@ -266,6 +267,7 @@ class ScoreCalculator {
 
                 const resample = new SampleData(regressionResult.samples.fieldMap, resampleData);
                 const bootstrapRegressionResult = findRegression(resample, predominantProfile);
+                //console.log('regression', bootstrapRegressionResult.regression);
                 if (bootstrapRegressionResult.regression.t2 < 0) {
                   // A positive slope means the frame rate decreased with increased complexity (which is the expected
                   // benavior). OTOH, a negative slope means the framerate increased as the complexity increased. This

--- a/MotionMark/resources/strings.js
+++ b/MotionMark/resources/strings.js
@@ -78,7 +78,9 @@ var Strings = {
 
         profiles: {
             slope: "slope",
-            flat: "flat"
+            flat: "flat",
+            window: "window",
+            windowStrict: "window-strict",
         },
 
         results: {

--- a/MotionMark/tests/resources/controllers.js
+++ b/MotionMark/tests/resources/controllers.js
@@ -170,10 +170,15 @@ class Controller {
     {
         return samples[sampleTimeIndex][i] - samples[sampleTimeIndex][i - 1];
     }
+
+    _getFrameTime(samples, i)
+    {
+        return samples[sampleTimeIndex][i];
+    }
     
     _previousFrameComplexity(samples, i)
     {
-        if (i > 0)
+        if (i > 1)
             return this._getComplexity(samples, i - 1);
 
         return 0;
@@ -399,6 +404,7 @@ class RampController extends Controller {
         super(benchmark, options);
         
         this.targetFPS = targetFPS;
+        this.preferredProfile = options["score-profile"];
 
         // Initially start with a tier test to find the bounds
         // The number of objects in a tier test is 10^|_tier|
@@ -586,10 +592,15 @@ class RampController extends Controller {
         for (var i = this._rampStartIndex; i < this._sampler.sampleCount; ++i) {
             if (this._getFrameType(this._sampler.samples, i) == Strings.json.mutationFrameType)
                 continue;
-            regressionData.push([ this._getComplexity(this._sampler.samples, i), this._getFrameLength(this._sampler.samples, i) ]);
+            regressionData.push(
+                [
+                    this._getComplexity(this._sampler.samples, i), 
+                    this._getFrameLength(this._sampler.samples, i),
+                    this._getFrameTime(this._sampler.samples, i)
+                ]);
         }
 
-        var regression = new Regression(regressionData, this._sampler.sampleCount - 1, this._rampStartIndex, { desiredFrameLength: this.frameLengthDesired });
+        var regression = new Regression(regressionData, this._sampler.sampleCount - 1, this._rampStartIndex, { desiredFrameLength: this.frameLengthDesired, preferredProfile: this.preferredProfile });
         this._rampRegressions.push(regression);
 
         var frameLengthAtMaxComplexity = regression.valueAt(this._maximumComplexity);


### PR DESCRIPTION
Experimental windowed score functions.

This adds "Windowed" and "Windowed Strict" score modes, that can be selected from the Developer page.

Windowed = the best score over a 10% window of samples, reaching 90% or more of the target framerate.
Windowed Strict = the best score over a 10% window of samples, searching from lowest-to-highest complexity, that never drops below 90% of the target framerate.

A comparison of ramp scores:

**Slope**
<img width="2520" height="1785" alt="image" src="https://github.com/user-attachments/assets/197fa44a-ba19-45c7-92a4-8d9887a93c44" />

**Windowed**
<img width="2520" height="1785" alt="image" src="https://github.com/user-attachments/assets/7e2ac128-42d9-49f9-898a-143985b451b5" />

**Windowed Strict**
<img width="2520" height="1785" alt="image" src="https://github.com/user-attachments/assets/8cfd48bd-1cad-41c3-90ee-a827f8f25272" />

Overall `Windowed Strict` looks the most promising as far as giving stable, and *explainable* results.