### PR TITLE
Fixes for maximum stage complexity calculation

### DIFF
--- a/MotionMark/tests/resources/controllers.js
+++ b/MotionMark/tests/resources/controllers.js
@@ -489,6 +489,11 @@ class RampController extends Controller {
                 var nextTierComplexity = Math.max(Math.round(Math.pow(10, this._tier)), currentComplexity + 1);
                 stage.tune(nextTierComplexity - currentComplexity);
 
+                // If the next tier complexity couldn't be set, we've reached the maximum capacity for the test
+                if (stage.complexity() != nextTierComplexity) {
+                   this._maximumStageComplexity = stage.complexity();
+                }
+
                 // Some tests may be unable to go beyond a certain capacity. If so, don't keep moving up tiers
                 if (stage.complexity() - currentComplexity > 0 || nextTierComplexity == 1) {
                     this._tierStartTimestamp = timestamp;
@@ -519,6 +524,12 @@ class RampController extends Controller {
             else {
                 // If the browser is capable of handling the most complex version of the test, use that
                 this._maximumComplexity = currentComplexity;
+            }
+
+            if (this._maximumStageComplexity) {
+                // If we reached the maximum stage complexity, set the maximum such
+                // that the stage complexity is in the middle of the ramp.
+                this._maximumComplexity = Math.round(this._maximumStageComplexity * 1.25);
             }
             
             this._possibleMaximumComplexity = this._maximumComplexity;
@@ -614,6 +625,12 @@ class RampController extends Controller {
         } else {
             // The slowest samples weighed the regression too heavily
             this._maximumComplexity = Math.max(Math.round(.8 * this._maximumComplexity), this._minimumComplexity + 5);
+        }
+
+        if (this._maximumStageComplexity) {
+            // If we reached the maximum stage complexity, set the maximum such
+            // that the stage complexity is in the middle of the ramp.
+            this._maximumComplexity = Math.min(Math.round(this._maximumStageComplexity * 1.25), this._maximumComplexity);
         }
 
         // Next ramp


### PR DESCRIPTION
This change helps to address an issue with scoring when tests reach the maximum complexity that a story supports. Currently this only applies to the "Multiply" test among the mainline tests.

For the following screenshots, I've artificially limited the "Multiply" test's totalRows to 10 (for a maximum stage complexity of 135) highlight this issue.

When a test reaches the maximum stage complexity, the controller can try to test a much higher complexity than the stage supports, since the code estimating the maximum complexity isn't aware of the stage's limit. This is particularly an issue for the Slope Profile, which has a harder time calculating the score when all samples are basically in a flat line.

## Before
### Slope Profile
<img width="3042" height="1726" alt="max_complexity_slope_before" src="https://github.com/user-attachments/assets/0c0876bd-0feb-423c-8d7a-d37871116445" />

## After
### Slope Profile
<img width="3042" height="1726" alt="max_complexity_slope_after" src="https://github.com/user-attachments/assets/51a38431-5d8d-44ba-9e62-9639e1850447" />

**Note:** the Slope score being less than 135 in the "After" picture isn't because of this change. The Slope regression is hit & miss either way, but is generally more predictable after this change. The *Mean* ramp score is pretty noisy with the Slope function as we can see.

### Windowed Strict Profile
<img width="3042" height="1726" alt="max_complexity_windowed_strict_after" src="https://github.com/user-attachments/assets/1bd08d31-90cb-4675-9d23-8060b9011ad6" />

For the Windowed Strict profile, the score is generally more accurate with or without this change.