### PR TITLE
Adjust Alice item sizing

### DIFF
--- a/MotionMark/resources/runner/motionmark.js
+++ b/MotionMark/resources/runner/motionmark.js
@@ -177,7 +177,7 @@ class BenchmarkController {
 
     determineCanvasSize()
     {
-        var match = window.matchMedia("(max-device-width: 760px)");
+        let match = window.matchMedia("(max-device-width: 760px)");
         if (match.matches) {
             document.body.classList.add("small");
             return;

--- a/MotionMark/tests/dev/alice/alice.html
+++ b/MotionMark/tests/dev/alice/alice.html
@@ -32,7 +32,9 @@
             --dropcap-stroke-color: #000080;
             --dropcap-fill-color: #400080;
             --text-color-1: #800040;
-            --text-color-2: #6666FE;   
+            --text-color-2: #6666FE;
+            -webkit-text-size-adjust: none;
+            text-size-adjust: none;
         }
 
         @font-face {
@@ -48,20 +50,27 @@
         }
 
         #container {
+            position: relative;
+            container-type: size;
             width: 100%;
             height: 100%;
         }
         
+        /* This is the element that takes writing-mode */
+        .wrapper {
+            width: 100%;
+            height: 100%;
+        }
+
         #container {
             .item {
                 position: absolute;
                 font-family: "Linden Hill", serif;
-                width: 30vw;
+                width: 30cqw;
+                height: 50cqh;
                 border: 1px solid black;
                 padding: 12px;
                 background-color: white;
-                overflow: clip;
-
                 animation: textColor 2s alternate infinite ease-in;
                 animation-delay: calc(-1 * var(--random) * 1ms);
             }
@@ -81,11 +90,10 @@
                 text-underline-offset: 5px;
                 text-rendering: optimizeLegibility;
                 font-variant: small-caps;
-                text-wrap: no-wrap;
-                
+                text-wrap: nowrap;
                 text-shadow: 3px 3px 0 color-mix(in srgb, currentColor, transparent 94%);
             }
-            
+
             .item p {
                 margin-block-start: 0.6em;
                 margin-inline-start: 0.3em;
@@ -110,39 +118,63 @@
             }
         }
 
-        @keyframes textColor {
-            from { color: var(--text-color-1); }
-            to   { color: var(--text-color-2); }
-        }
-
-        #container.picture-wall {
-            perspective: 100vw;
-            perspective-origin: center;
-            transform-style: preserve-3d;
-            display: grid;
-        }
-
-        #container.picture-wall .item {
-            grid-area: 1/1;
-            max-width: 50vw;
-            max-height: 26vh;
-            overflow: clip;
-            place-self: start center;
-            transform-origin: top center;
-        }
-        
         #container.layout-random .item {
             opacity: 0.9;
             grid-area: 1/1;
-            max-width: 40vw;
-            max-height: 30vh;
+            width: 35cqw;
+            height: 40cqh;
             overflow: clip;
             place-self: start center;
+        }        
+
+        @container (width <= 900px) {
+            #container {
+                h1.heading {
+                    font-size: 18pt;
+                    margin: 0 0 6pt 0;
+                }
+
+                .item {
+                    padding: 6px;
+                    width: 50cqw;
+                    height: 45cqh;
+                }
+
+                .item p:first-letter {
+                    font-size: 200%;
+                }
+            }
+
+            #container.layout-random {
+                .item {
+                    width: 55cqw;
+                    height: 55cqh;
+                }
+            }
         }
-        
-        .wrapper {
-            width: 100%;
-            height: 100%;
+
+        @container (width < 600px) {
+            #container {
+                h1.heading {
+                    font-size: 16pt;
+                }
+
+                .item p {
+                    font-size: 12pt;
+                }
+            }
+
+            #container.layout-random {
+                .item {
+                    width: 55cqw;
+                    height: 55cqh;
+                }
+            }
+        }
+
+        @keyframes textColor {
+            from { color: var(--text-color-1); }
+            to   { color: var(--text-color-2); }
         }
     </style>
 </head>

--- a/MotionMark/tests/dev/alice/resources/alice.js
+++ b/MotionMark/tests/dev/alice/resources/alice.js
@@ -75,12 +75,10 @@ class RandomPlacementLayout extends ItemLayout {
 
             const x = Stage.randomInt(-allowedMinXClip, this._stageSize.width - allowedMaxXClip);
             const y = Stage.randomInt(-allowedMinYClip, this._stageSize.height - allowedMaxYClip);
-            
-            console.log(`allowedMinYClip ${allowedMinYClip} allowedMaxYClip ${allowedMaxYClip} y ${y} item height ${this._itemSize.height}`);
-        
+
             element.style.left = `${x}px`;
             element.style.top = `${y}px`;
-            
+
             if (this._drifting) {
                 const driftScalarMin = -0.5;
                 const driftScalarMax = 0.5;

--- a/MotionMark/tests/dev/stories/stories.html
+++ b/MotionMark/tests/dev/stories/stories.html
@@ -28,6 +28,10 @@
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="../../resources/stage.css">
     <style>
+        :root {
+            -webkit-text-size-adjust: none;
+            text-size-adjust: none;
+        }
 
         @property --image-scale {
           syntax: "<number>";


### PR DESCRIPTION
Use more appropriate sizes for “medium” and “small” stages, based on container query units.

Also turn off text auto-sizing for mobile devices.