### PR TITLE
Fix starting a specific suite

### DIFF
--- a/MotionMark/resources/debug-runner/debug-runner.js
+++ b/MotionMark/resources/debug-runner/debug-runner.js
@@ -494,7 +494,7 @@ window.suitesManager = new class SuitesManager {
 
             var test;
             for (var j = 0; j < suite.tests.length; ++j) {
-                suiteTest = suite.tests[j];
+                var suiteTest = suite.tests[j];
                 if (Utilities.stripUnwantedCharactersForURL(suiteTest.name).match(testRegExp)) {
                     test = suiteTest;
                     break;


### PR DESCRIPTION
If you go developer.html there is a link by each test. Clicking the link presents a URL. Those URLs don't work as they get an error "suiteTest is undefined"

This is the fix.