### PR TITLE
Switch links from `<span>` to `<a>`

### DIFF
--- a/MotionMark/resources/debug-runner/debug-runner.js
+++ b/MotionMark/resources/debug-runner/debug-runner.js
@@ -356,25 +356,29 @@ window.suitesManager = new class SuitesManager {
         span.appendChild(document.createTextNode(" " + test.name + " "));
 
         testElement.appendChild(document.createTextNode(" "));
-        var link = Utilities.createElement("span", {}, testElement);
+        var link = Utilities.createElement("a", {}, testElement);
         link.classList.add("link");
         link.textContent = "link";
         link.suiteName = Utilities.stripUnwantedCharactersForURL(suiteCheckbox.suite.name);
         link.testName = test.name;
-        link.onclick = function(event) {
-            var element = event.target;
-            var title = "Link to run “" + element.testName + "” with current options:";
-            var url = location.href.split(/[?#]/)[0];
+        
+        function updateLinkHref() {
             var options = optionsManager.updateLocalStorageFromUI();
             Utilities.extendObject(options, {
-                "suite-name": element.suiteName,
-                "test-name": Utilities.stripUnwantedCharactersForURL(element.testName)
+                "suite-name": link.suiteName,
+                "test-name": Utilities.stripUnwantedCharactersForURL(link.testName)
             });
-            var complexity = suitesManager._editElement(element.parentNode).value;
-            if (complexity)
-                options.complexity = complexity;
-            prompt(title, url + Utilities.convertObjectToQueryString(options));
-        };
+            var complexityInput = link.parentNode.querySelector("input[type='number']");
+            if (complexityInput && complexityInput.value)
+                options.complexity = complexityInput.value;
+            
+            var url = location.href.split(/[?#]/)[0];
+            link.href = url + Utilities.convertObjectToQueryString(options);
+        }
+        
+        link.addEventListener("mouseenter", updateLinkHref);
+        link.addEventListener("focus", updateLinkHref);
+        link.addEventListener("click", updateLinkHref);
 
         var complexity = Utilities.createElement("input", { type: "number" }, testElement);
         complexity.relatedCheckbox = testCheckbox;

--- a/MotionMark/resources/debug-runner/motionmark.css
+++ b/MotionMark/resources/debug-runner/motionmark.css
@@ -168,10 +168,15 @@ label.tree-label {
 
 .tree .link {
     cursor: pointer;
-    color: #999;
     font-style: italic;
     margin-left: 2em;
+    text-decoration: none;
 }
+
+#intro .tree .link {
+    color: #999;
+}
+
 
 @media screen and (max-device-width: 414px),
     screen and (max-device-height: 414px) and (orientation: landscape) {


### PR DESCRIPTION
The links in the developer.html were spans with an onclick handler that called `prompt` with a URL. This meant to use the link you had to manaully copy and paste it.

<img width="287" height="350" alt="Screenshot 2026-05-28 at 10 59 48" src="https://github.com/user-attachments/assets/ead00ebb-de57-4209-b9b7-131d4665c9d4" />


Switching to `<a>` means you can just click the link. You can still copy the link by right clicking and picking copy link or long pressing on mobile. The link should still update to the correct value.

Note: the links won't actually work without https://github.com/WebKit/MotionMark/pull/109