### PR TITLE
Update rubric to recommend maximizing the browser window, instead of using "fullscreen"

### DIFF
--- a/MotionMark/about.html
+++ b/MotionMark/about.html
@@ -67,9 +67,9 @@
                 <li><strong>Suits</strong>: SVG clip paths, gradients and transforms</li>
             </ul>
 
-            <p>To achieve consistent results on mobile devices, put the device in landscape orientation. On laptops and desktops, use the default display resolution and make the browser window fullscreen. Make sure that screen automatic display sleep is turned off or set to longer than 8 minutes.</p>
+            <p>To achieve consistent results on mobile devices, put the device in landscape orientation. On laptops and desktops, use the default display resolution and maximize the browser window while keeping system UI visible. Make sure that screen automatic display sleep is turned off or set to longer than 8 minutes.</p>
 
-            <p id="set-display-fps">The MotionMark benchmark relies on the requestAnimationFrame() JavaScript API, which provides callbacks at a consistent frequency related to screen refresh rate. However, browsers have made different choices about whether requestAnimationFrame() should strictly follow screen refresh rate. Safari currently fires requestAnimationFrame() callbacks at 60Hz on 120Hz screens, while other browsers fire it at 120Hz. This affects the benchmark score, so to compare browser scores across browsers, be sure to set the screen refresh rate to 60Hz (for example on macOS, this can be done in the Displays panel in System Settings).</p>
+            <p id="set-display-fps">The MotionMark benchmark relies on the <code>requestAnimationFrame()</code> JavaScript API, which provides callbacks at a consistent frequency related to screen refresh rate. However, browsers have made different choices about whether <code>requestAnimationFrame()</code> should strictly follow screen refresh rate. Safari currently fires <code>requestAnimationFrame()</code> callbacks at 60Hz on 120Hz screens, while other browsers fire it at 120Hz. This affects the benchmark score, so to compare browser scores across browsers, be sure to set the screen refresh rate to 60Hz (for example on macOS, this can be done in the Displays panel in System Settings).</p>
 
             <h3>Version history</h3>
             <ul id="log">

--- a/MotionMark/developer.html
+++ b/MotionMark/developer.html
@@ -116,7 +116,7 @@
                     </div>
                 </div>
                 <p>
-                    For accurate results, please take the browser window full screen, or rotate the device to landscape orientation. Also,
+                    For accurate results, please maximize the browser window, or rotate the device to landscape orientation. Also,
                     ensure that the target frame rate matches your system frame rate. Results cannot be compared between devices that
                     use different frame rates.
                 </p>

--- a/MotionMark/index.html
+++ b/MotionMark/index.html
@@ -60,7 +60,7 @@
                 <p>MotionMark is a graphics benchmark that measures a browser’s capability to animate complex scenes at a target frame rate.</p>
 
                 <p><a href="about.html">More details</a> about the benchmark are available. Bigger scores are better.</p>
-                <p>For accurate results, please take your browser window full screen, or rotate your device to landscape orientation.</p>
+                <p>For accurate results, please maximize your browser window, or rotate your device to landscape orientation.</p>
                 <p class="portrait-orientation-check"><b>Please rotate your device.</b></p>
                 <button id="start-button" class="landscape-orientation-check" onclick="benchmarkController.startBenchmark()">Run Benchmark</button>
                 <p id="frame-rate-label">&nbsp;</p>


### PR DESCRIPTION
As discussed[1], change the rubric to suggest maximizing the browser window, instead of taking it into fullscreen. The about page clarifies that leaves system UI visible (i.e. the macOS use of "maximize").

[1] https://docs.google.com/document/d/10dE1HHht5j1F4woUu8Z9pClksWU1gO7GUPQU-Rn_ah8/#heading=h.lmrf9obg3lrc